### PR TITLE
配置使用绝对路径时，使用trim后得到的是相对路径，无法得到正确的路径，故改为rtrim

### DIFF
--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -213,7 +213,7 @@ EOT;
             return $path;
         }
 
-        return trim(config('admin.upload.host'), '/').'/'.trim($path, '/');
+        return rtrim(config('admin.upload.host'), '/').'/'.trim($path, '/');
     }
 
     /**


### PR DESCRIPTION
比如配置adminj.upload.host为/upload，最后渲染成为upload/balabala，成为相对路径