### PR TITLE
当字段为数组时，比如image[]时，字段id过滤掉方括号（[]）

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -153,7 +153,7 @@ class Field
      */
     protected function formatId($column)
     {
-        return str_replace('.', '_', $column);
+        return str_replace('.', '_', trim($column, '[]'));
     }
 
     /**


### PR DESCRIPTION
如题，感觉需要进行统一全过滤，毕竟涉及到js选择器