### PR TITLE
add ability to use validation rules like ‘after:other_date_field’

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -383,7 +383,7 @@ class Field
      */
     public function validate(array $input)
     {
-        $data = $rules = [];
+        $rules = $attributes = [];
 
         if (!$fieldRules = $this->getRules()) {
             return false;
@@ -401,8 +401,8 @@ class Field
                 $value = array_filter($value);
             }
 
-            $data[$this->label] = $value;
-            $rules[$this->label] = $fieldRules;
+            $rules[$this->column] = $fieldRules;
+            $attributes[$this->column] = $this->label;
         }
 
         if (is_array($this->column)) {
@@ -410,12 +410,13 @@ class Field
                 if (!array_key_exists($column, $input)) {
                     continue;
                 }
-                $data[$this->label.$key] = array_get($input, $column);
-                $rules[$this->label.$key] = $fieldRules;
+                $input[$this->column.$key] = array_get($input, $column);
+                $rules[$this->column.$key] = $fieldRules;
+                $attributes[$this->column.$key] = $this->label;
             }
         }
 
-        return Validator::make($data, $rules);
+        return Validator::make($input, $rules, [], $attributes);
     }
 
     /**

--- a/views/form/checkbox.blade.php
+++ b/views/form/checkbox.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/code.blade.php
+++ b/views/form/code.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/color.blade.php
+++ b/views/form/color.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/currency.blade.php
+++ b/views/form/currency.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/date.blade.php
+++ b/views/form/date.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/daterange.blade.php
+++ b/views/form/daterange.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id['start']}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/datetime.blade.php
+++ b/views/form/datetime.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/datetimerange.blade.php
+++ b/views/form/datetimerange.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id['start']}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/decimal.blade.php
+++ b/views/form/decimal.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/editor.blade.php
+++ b/views/form/editor.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/email.blade.php
+++ b/views/form/email.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/error.blade.php
+++ b/views/form/error.blade.php
@@ -1,5 +1,5 @@
-@if($errors->has($label))
-    @foreach($errors->get($label) as $message)
-        <label class="control-label" for="inputError"><i class="fa fa-times-circle-o"></i>{{$message}}</label></br>
+@if($errors->has($column))
+    @foreach($errors->get($column) as $message)
+        <label class="control-label" for="inputError"><i class="fa fa-times-circle-o"></i> {{$message}}</label></br>
     @endforeach
 @endif

--- a/views/form/file.blade.php
+++ b/views/form/file.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/image.blade.php
+++ b/views/form/image.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/ip.blade.php
+++ b/views/form/ip.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/json.blade.php
+++ b/views/form/json.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/map.blade.php
+++ b/views/form/map.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id['lat']}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/mobile.blade.php
+++ b/views/form/mobile.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/multipleselect.blade.php
+++ b/views/form/multipleselect.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/number.blade.php
+++ b/views/form/number.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/password.blade.php
+++ b/views/form/password.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/radio.blade.php
+++ b/views/form/radio.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/rate.blade.php
+++ b/views/form/rate.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/select.blade.php
+++ b/views/form/select.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
 <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/slider.blade.php
+++ b/views/form/slider.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/switchfield.blade.php
+++ b/views/form/switchfield.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/text.blade.php
+++ b/views/form/text.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/textarea.blade.php
+++ b/views/form/textarea.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/time.blade.php
+++ b/views/form/time.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/timerange.blade.php
+++ b/views/form/timerange.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id['start']}}" class="col-sm-2 control-label">{{$label}}</label>
 

--- a/views/form/url.blade.php
+++ b/views/form/url.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {!! !$errors->has($label) ?: 'has-error' !!}">
+<div class="form-group {!! !$errors->has($column) ?: 'has-error' !!}">
 
     <label for="{{$id}}" class="col-sm-2 control-label">{{$label}}</label>
 


### PR DESCRIPTION
Imagine a form with 2 date fields where the second date's value has to be after the first one:

```php
$form->date('start_at', 'Start date')->rules('required|date');
$form->date('end_at', 'End date')->rules('required|date|after_or_equal:start_at');
```
This basic laravel validation does not work, since every `Encore\Admin\Form\Field` creates a new validator with only his own data and rules.

This change simple adds all other fields as data, but only validates the current field's rules.
It also changes all existing fields since we need to column name to compare fields, not the label. 

Error messages will still use the label in the message, since they are added to the validator by using the `customAttributes` parameter of `Validator::make()`


























