### PR TITLE
更新初始操作记录表的input内容字段类型

### DIFF
--- a/migrations/2016_01_04_173148_create_admin_tables.php
+++ b/migrations/2016_01_04_173148_create_admin_tables.php
@@ -82,7 +82,7 @@ class CreateAdminTables extends Migration
             $table->string('path');
             $table->string('method', 10);
             $table->string('ip', 15);
-            $table->text('input');
+            $table->longText('input');
             $table->index('user_id');
             $table->timestamps();
         });


### PR DESCRIPTION
问题来源：在应用input值过大的时候无法更新记录到日志操作表，导致数据不能提交。