### PR TITLE
Use grammar to quote identifier

### DIFF
--- a/src/Auth/Database/Menu.php
+++ b/src/Auth/Database/Menu.php
@@ -3,6 +3,8 @@
 namespace Encore\Admin\Auth\Database;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+
 
 /**
  * Class Menu.
@@ -66,7 +68,9 @@ class Menu extends Model
         $branch = [];
 
         if (empty($elements)) {
-            $elements = static::with('roles')->orderByRaw('`order` = 0,`order`')->get()->toArray();
+            $orderColumn = DB::getQueryGrammar()->wrap("order");
+            $byOrder = $orderColumn . ' = 0,' .$orderColumn;
+            $elements = static::with('roles')->orderByRaw($byOrder)->get()->toArray();
         }
 
         foreach ($elements as $element) {
@@ -141,7 +145,9 @@ class Menu extends Model
         $options = [];
 
         if (empty($elements)) {
-            $elements = static::orderByRaw('`order` = 0,`order`')->get(['id', 'parent_id', 'title'])->toArray();
+            $orderColumn = DB::getQueryGrammar()->wrap("order");
+            $byOrder = $orderColumn . ' = 0,' .$orderColumn;
+            $elements = static::orderByRaw($byOrder)->get(['id', 'parent_id', 'title'])->toArray();
         }
 
         foreach ($elements as $element) {


### PR DESCRIPTION
Fixes https://github.com/z-song/laravel-admin/issues/161

There are likely other places that need to use Grammar to quote identifiers. I'll update this PR as I learn the laravel-admin framework.