### PR TITLE
switch field needs to use the ‘default’ value if value is empty

### DIFF
--- a/src/Form/Field/SwitchField.php
+++ b/src/Form/Field/SwitchField.php
@@ -38,7 +38,7 @@ class SwitchField extends Field
     public function render()
     {
         foreach ($this->states as $state => $option) {
-            if ($this->value == $option['value']) {
+            if ($this->value() == $option['value']) {
                 $this->value = $state;
                 break;
             }


### PR DESCRIPTION
Current code doesn't use the checkbox default value if empty
```php
$form->switch('a_boolean_field')->default(1);
```