### PR TITLE
number field does not longer ignore default value when rendering

### DIFF
--- a/src/Form/Field/Number.php
+++ b/src/Form/Field/Number.php
@@ -12,7 +12,7 @@ class Number extends Field
 
     public function render()
     {
-        $this->default(0);
+        $this->default((int)$this->default);
 
         $this->script = <<<EOT
 


### PR DESCRIPTION
The default value for the number field gets ignored

```php
$form->number('quantity')->default(1); // still shows 0
```