### PR TITLE
add ability to save e.g. ‘0’ to fields in a nested form

### DIFF
--- a/src/Form/NestedForm.php
+++ b/src/Form/NestedForm.php
@@ -195,7 +195,7 @@ class NestedForm
 
             $value = $this->fetchColumnValue($record, $columns);
 
-            if (empty($value)) {
+            if (is_null($value)) {
                 continue;
             }
 


### PR DESCRIPTION
Fields in a nested form don’t store values that are considered empty by PHP’s ‘empty’ function. Use is_null instead as used in the ‘prepare’ method inside Form