### PR TITLE
input attribute values need to be escaped

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -601,7 +601,7 @@ class Field
         $html = [];
 
         foreach ($this->attributes as $name => $value) {
-            $html[] = "$name=\"$value\"";
+            $html[] = $name.'="'.e($value).'"';
         }
 
         return implode(' ', $html);


### PR DESCRIPTION
if you input something like ‘this is a “test” with quotes’ it stores the value correctly, but next refresh will only show ‘this is a ‘