### PR TITLE
fix incorrect selected value in grid filter when options are [0=>’off’, 1=>’on’]

### DIFF
--- a/views/filter/select.blade.php
+++ b/views/filter/select.blade.php
@@ -1,5 +1,5 @@
 <select class="form-control {{ $class }}" style="width: 100%;" name="{{$name}}">
     @foreach($options as $select => $option)
-        <option value="{{$select}}" {{ $select == request($name, $value) ?'selected':'' }}>{{$option}}</option>
+        <option value="{{$select}}" {{ (string)$select === request($name, $value) ?'selected':'' }}>{{$option}}</option>
     @endforeach
 </select>


### PR DESCRIPTION
If you create a filter in the grid with these options:
```php
$filter->equal('is_paid')->select(['0' => 'no', '1' => 'yes']);
```
'no' is selected by default even if no filter is applied.