### PR TITLE
HasMany: new rows get original data from previous defined rows

### DIFF
--- a/src/Form/NestedForm.php
+++ b/src/Form/NestedForm.php
@@ -169,13 +169,13 @@ class NestedForm
      */
     protected function setFieldOriginalValue($key)
     {
+        $values = [];
         if (array_key_exists($key, $this->original)) {
             $values = $this->original[$key];
-
-            $this->fields->each(function (Field $field) use ($values) {
-                $field->setOriginal($values);
-            });
         }
+        $this->fields->each(function (Field $field) use ($values) {
+            $field->setOriginal($values);
+        });
     }
 
     /**


### PR DESCRIPTION
new rows get original data from previous defined rows leading to weird behaviour

if the hasMany component already has e.g.. 3 existing rows and you add a new one, the new row’s original data gets filled in with the last defined original data

fixes #341 again