### PR TITLE
Fix #396

### DIFF
--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -4,6 +4,24 @@ namespace Encore\Admin\Form\Field;
 
 class MultipleSelect extends Select
 {
+
+    /**
+     * Pivot column name.
+     *
+     * @var string
+     */
+    protected $pivotColumn = '';
+
+    public function __construct($column, $arguments = [])
+    {
+        if (isset($arguments[1])) {
+            parent::__construct($column, array($arguments[1]));
+            $this->pivotColumn = $arguments[0];
+        } else {
+            parent::__construct($column, $arguments);
+        }
+    }
+
     public function fill($data)
     {
         $relations = array_get($data, $this->column);
@@ -17,7 +35,11 @@ class MultipleSelect extends Select
                 $this->value = $relations;
             } else {
                 foreach ($relations as $relation) {
-                    $this->value[] = array_pop($relation['pivot']);
+                    if (!empty($this->pivotColumn)) {
+                        $this->value[] = $relation['pivot'][$this->pivotColumn];
+                    } else {
+                        $this->value[] = array_pop($relation['pivot']);
+                    }
                 }
             }
         }
@@ -36,7 +58,11 @@ class MultipleSelect extends Select
                 $this->original = $relations;
             } else {
                 foreach ($relations as $relation) {
-                    $this->original[] = array_pop($relation['pivot']);
+                    if (!empty($this->pivotColumn)) {
+                        $this->value[] = $relation['pivot'][$this->pivotColumn];
+                    } else {
+                        $this->value[] = array_pop($relation['pivot']);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR tries to fix https://github.com/z-song/laravel-admin/issues/396 by adding an option `pivotColumn` when creating multipleSelect field so that the correct key of the pivot table can be used. The old behaviour is still there if no `pivotColumn` option is set.

So now you can create a multipleSelect like this, the `tag_id` column will be used explicitly as the key to get the value from pivot table.

```
class PostController extends Controller {
......
    protected function form()
    {
            ....

            $form->multipleSelect('tags', 'tag_id', 'Tags')->options(function () use ($form) {
                if ($form->model()->id) { // create mode
                    $tags = $form->model()->tags;

                    if ($tags) {
                        return $tags->pluck('name', 'id');
                    }
                }
            })->ajax('/'.config('admin.prefix').'/api/tags');
            ....
    }
}
```