### PR TITLE
add operation_log_settings to exclude request methods and limit logs

### DIFF
--- a/config/admin.php
+++ b/config/admin.php
@@ -92,6 +92,10 @@ return [
      * By setting this option to open or close operation log in laravel-admin.
      */
     'operation_log'   => true,
+    'operation_log_settings' => [
+        'exclude_methods' => [],
+        'max_age_in_days' => null,
+    ],
 
     /*
     |---------------------------------------------------------|

--- a/src/Middleware/OperationLog.php
+++ b/src/Middleware/OperationLog.php
@@ -2,6 +2,7 @@
 
 namespace Encore\Admin\Middleware;
 
+use Carbon\Carbon;
 use Encore\Admin\Facades\Admin;
 use Illuminate\Http\Request;
 
@@ -18,15 +19,31 @@ class OperationLog
     public function handle(Request $request, \Closure $next)
     {
         if (config('admin.operation_log') && Admin::user()) {
-            $log = [
-                'user_id' => Admin::user()->id,
-                'path'    => $request->path(),
-                'method'  => $request->method(),
-                'ip'      => $request->getClientIp(),
-                'input'   => json_encode($request->input()),
-            ];
 
-            \Encore\Admin\Auth\Database\OperationLog::create($log);
+            // log if request method is not excluded
+            $method = $request->method();
+            $excludedMethods = (array)config('admin.operation_log_settings.exclude_methods');
+            if (!in_array($method, $excludedMethods)) {
+                $log = [
+                    'user_id' => Admin::user()->id,
+                    'path' => $request->path(),
+                    'method' => $method,
+                    'ip' => $request->getClientIp(),
+                    'input' => json_encode($request->input()),
+                ];
+
+                \Encore\Admin\Auth\Database\OperationLog::create($log);
+            }
+
+            // clear logs once a day if max age is defined
+            $maxDays = (int)config('admin.operation_log_settings.max_age_in_days');
+            $cacheKey = 'LA_logs_cleared';
+            if ($maxDays > 0 && !\Cache::has($cacheKey)) {
+                \Encore\Admin\Auth\Database\OperationLog::
+                whereDate('created_at', '>', Carbon::now()->addDays($maxDays)->toDateString())
+                    ->delete();
+                \Cache::put($cacheKey, true, 60 * 24);
+            }
         }
 
         return $next($request);


### PR DESCRIPTION
```php

    'operation_log_settings' => [
        'exclude_methods' => ['GET'],
        'max_age_in_days' => 100,
    ]
```

add options to limit the log:
- don't log certain methods eg (GET)
- delete logs older then 100 days
The delete option only gets executed once a day

I kept the original 'operation_log' config setting for backward compatibility reasons
This would be nicer, but would be a breaking change:
```php

    'operation_log' => [
        'active' => true,
        'exclude_methods' => ['GET'],
        'max_age_in_days' => 100,
    ]
```