### PR TITLE
bootstrap.php needs to be called before Form::collectFieldAssets()

### DIFF
--- a/src/Middleware/BootstrapMiddleware.php
+++ b/src/Middleware/BootstrapMiddleware.php
@@ -12,13 +12,13 @@ class BootstrapMiddleware
     {
         Form::registerBuiltinFields();
 
-        Form::collectFieldAssets();
-
-        Grid::registerColumnDisplayer();
-
         if (file_exists($bootstrap = admin_path('bootstrap.php'))) {
             require $bootstrap;
         }
+
+        Form::collectFieldAssets();
+
+        Grid::registerColumnDisplayer();
 
         return $next($request);
     }


### PR DESCRIPTION
If you use Form::extend or Form::forget in bootstrap.php it’s assets were not required/forgotten


I for example don't use the map field, yet still its resources got loaded
another custom field didn't get its assets