### PR TITLE
fix the has many relation function name in hump type can not match data

### DIFF
--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -77,6 +77,16 @@ class HasMany extends Field
         }
     }
 
+	/**
+	 * fix the has many relation function name in hump type can not match data
+	 *
+	 * @param array $data
+	 */
+	public function fill($data)
+	{
+		$this->value = array_get($data, snake_case($this->column));
+	}
+
     /**
      * Get validator for this field.
      *


### PR DESCRIPTION
修正当model的hasMany方法为驼峰式的时候，无法匹配到数据。