### PR TITLE
Removed few dead end routes.

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -259,13 +259,11 @@ class Admin
 
             /* @var \Illuminate\Routing\Router $router */
             $router->group($attributes, function ($router) {
-                $router->resources([
-                    'auth/users'       => 'UserController',
-                    'auth/roles'       => 'RoleController',
-                    'auth/permissions' => 'PermissionController',
-                    'auth/menu'        => 'MenuController',
-                    'auth/logs'        => 'LogController',
-                ]);
+                $router->resource('auth/users', 'UserController');
+                $router->resource('auth/roles', 'RoleController');
+                $router->resource('auth/permissions', 'PermissionController');
+                $router->resource('auth/menu', 'MenuController', ['except' => ['create']]);
+                $router->resource('auth/logs', 'LogController', ['only' => ['index', 'destroy']]);
             });
 
             $router->get('auth/login', 'AuthController@getLogin');


### PR DESCRIPTION
Using `$router->resources()` you can't specify `options`. So using `$router->resource()` instead and removed routes which doesn't have any methods.