### PR TITLE
fix Editable class

### DIFF
--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -138,7 +138,7 @@ class Editable extends AbstractDisplayer
     {
         $this->options['name'] = $column = $this->column->getName();
 
-        $class = "grid-editable-$column";
+        $class = 'grid-editable-' . str_replace(['.','#','[',']'], '-',$column);
 
         $this->buildEditableOptions(func_get_args());
 


### PR DESCRIPTION
当editable的column带 ```.``` 的时候，会出现错误。