### PR TITLE
swap the order for creating columns through the magic method

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -840,15 +840,15 @@ class Grid
             return $this->addColumn($method, $label);
         }
 
-        if ($column = $this->handleTableColumn($method, $label)) {
-            return $column;
-        }
-
         if ($column = $this->handleGetMutatorColumn($method, $label)) {
             return $column;
         }
 
         if ($column = $this->handleRelationColumn($method, $label)) {
+            return $column;
+        }
+
+        if ($column = $this->handleTableColumn($method, $label)) {
             return $column;
         }
 


### PR DESCRIPTION
if the column is a relation, there is no need to check if it’s a column in the database
this way we don’t need a query if the column is a mutator or relation

eg
```
$grid->pack_products(); // this is a HasMany relation
```

Currently it checks first if 'pack_products' is a column, but it should check first if it's a mutation or a relation. This way we skip the redundant call to the database.

BTW
if i use `$grid->column('pack_products');` the model doesn't use the `->with('pack_products')` for some reason.
