### PR TITLE
Field->elementClass needs to be an array

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -68,11 +68,11 @@ class Field implements Renderable
     protected $elementName = [];
 
     /**
-     * Form element name.
+     * Form element classes.
      *
      * @var string
      */
-    protected $elementClass = '';
+    protected $elementClass = [];
 
     /**
      * Variables of elements.


### PR DESCRIPTION
Calling $field->addElementClass('someClass') throws an error because $this->elementClass is not an array by default, so the merge fails