### PR TITLE
Model form fix

### DIFF
--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -156,10 +156,13 @@ class Builder
     /**
      * @return string
      */
-    public function getResource()
+    public function getResource($slice = null)
     {
         if ($this->mode == self::MODE_CREATE) {
             return $this->form->resource(-1);
+        }
+        if ($slice !== null) {
+            return $this->form->resource($slice);
         }
 
         return $this->form->resource();
@@ -482,7 +485,7 @@ if ($('.has-error').length) {
         var tabId = '#'+$(this).closest('.tab-pane').attr('id');
         $('li a[href="'+tabId+'"] i').removeClass('hide');
     });
-    
+
     var first = $('.has-error:first').closest('.tab-pane').attr('id');
     $('li a[href="#'+first+'"]').tab('show');
 }

--- a/src/Form/Tools.php
+++ b/src/Form/Tools.php
@@ -7,6 +7,7 @@ use Encore\Admin\Form;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class Tools implements Renderable
 {
@@ -67,7 +68,8 @@ EOT;
 
     public function listButton()
     {
-        $resource = $this->form->getResource();
+        $slice = Str::contains($this->form->getResource(0), "/edit") ? null : -1;
+        $resource = $this->form->getResource($slice);
 
         $text = trans('admin::lang.list');
 
@@ -105,7 +107,7 @@ EOT;
     }
 
     /**
-     * Disable batch actions.
+     * Disable list button.
      *
      * @return $this
      */

--- a/views/form.blade.php
+++ b/views/form.blade.php
@@ -33,7 +33,7 @@
         </div>
         <!-- /.box-body -->
         <div class="box-footer">
-            @if( ! $form->isMode(\Encore\Admin\Form\Builder::MODE_VIEW))
+            @if( ! $form->isMode(\Encore\Admin\Form\Builder::MODE_VIEW  || ! $form->options()['enableSubmit']))
                 <input type="hidden" name="_token" value="{{ csrf_token() }}">
             @endif
             <div class="col-sm-{{$width['label']}}">

--- a/views/form.blade.php
+++ b/views/form.blade.php
@@ -33,7 +33,9 @@
         </div>
         <!-- /.box-body -->
         <div class="box-footer">
-            <input type="hidden" name="_token" value="{{ csrf_token() }}">
+            @if( ! $form->isMode(\Encore\Admin\Form\Builder::MODE_VIEW))
+                <input type="hidden" name="_token" value="{{ csrf_token() }}">
+            @endif
             <div class="col-sm-{{$width['label']}}">
 
             </div>


### PR DESCRIPTION
A few small model-form errors:

  1. When the form->resource is something like ```http://example.com/resources/151/edit``` the 'List' button shows a 'list' link of ```http://example.com/resources/151``` instead of the correct ```http://example.com/resources```. This request fixes that by letting the form builder's getResource method accept a 'slice' argument, and altering the slice requested by the List button if '/edit' is in the url.
  2. When the form is in the undocumented 'view' mode, which displays the form but removes the 'Submit' button, or the Submit button is disabled, the form still contains a valid csrf_token meaning it could still be submitted manually. This request removes the csrf_token when there is no Submit button.