### PR TITLE
ide-helper grabs the wrong namespace when it’s not fully qualified

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -41,7 +41,7 @@ class Admin
      * @param $model
      * @param Closure $callable
      *
-     * @return Grid
+     * @return \Encore\Admin\Grid
      */
     public function grid($model, Closure $callable)
     {
@@ -52,7 +52,7 @@ class Admin
      * @param $model
      * @param Closure $callable
      *
-     * @return Form
+     * @return \Encore\Admin\Form
      */
     public function form($model, Closure $callable)
     {
@@ -64,7 +64,7 @@ class Admin
      *
      * @param $model
      *
-     * @return Tree
+     * @return \Encore\Admin\Tree
      */
     public function tree($model, Closure $callable = null)
     {
@@ -74,7 +74,7 @@ class Admin
     /**
      * @param Closure $callable
      *
-     * @return Content
+     * @return \Encore\Admin\Layout\Content
      */
     public function content(Closure $callable = null)
     {
@@ -235,7 +235,7 @@ class Admin
     /**
      * Get navbar object.
      *
-     * @return Navbar
+     * @return \Encore\Admin\Widgets\Navbar
      */
     public function getNavbar()
     {


### PR DESCRIPTION
This isn't really a laravel-admin problem, but it fixes a bug in the way laravel-ide-helper incorrectly identifies the class returned by a method, if the class isn't fully qualified in the method docblock. This causes PHPStorm to complain very loudly. 

Fully qualifying the class returned by these methods has no other side effects.