### PR TITLE
UploadField的默认配置会覆盖用户配置,修复此问题

### DIFF
--- a/src/Form/Field/UploadField.php
+++ b/src/Form/Field/UploadField.php
@@ -41,7 +41,7 @@ trait UploadField
      * Create a new File instance.
      *
      * @param string $column
-     * @param array $arguments
+     * @param array  $arguments
      */
     public function __construct($column, $arguments = [])
     {
@@ -60,30 +60,31 @@ trait UploadField
         $this->disk(config('admin.upload.disk'));
     }
 
+
     public function setupDefaultOptions()
     {
-        $this->options([
+        array_merge([
             'overwriteInitial'     => false,
             'initialPreviewAsData' => true,
             'browseLabel'          => trans('admin::lang.browse'),
             'showRemove'           => false,
             'showUpload'           => false,
-            'initialCaption'   => $this->initialCaption($this->value),
-            'deleteUrl'        => $this->form->resource() . '/'. $this->form->model()->getKey(),
-            'deleteExtraData'  => [
-                $this->column       => '',
+            'initialCaption'       => $this->initialCaption($this->value),
+            'deleteUrl'            => $this->form->resource().'/'.$this->form->model()->getKey(),
+            'deleteExtraData'      => [
+                $this->column            => '',
                 static::FILE_DELETE_FLAG => '',
-                '_token'            => csrf_token(),
-                '_method'           => 'PUT'
+                '_token'                 => csrf_token(),
+                '_method'                => 'PUT'
             ]
-        ]);
+        ], $this->options());
     }
 
     public function setupPreviewOptions()
     {
         $this->options([
-            'initialPreview'        => $this->preview(),
-            'initialPreviewConfig'  => $this->initialPreviewConfig(),
+            'initialPreview'       => $this->preview(),
+            'initialPreviewConfig' => $this->initialPreviewConfig(),
         ]);
     }
 
@@ -110,7 +111,7 @@ trait UploadField
      */
     public function disk($disk)
     {
-        if (!array_key_exists($disk, config('filesystems.disks'))) {
+        if (! array_key_exists($disk, config('filesystems.disks'))) {
             $error = new MessageBag([
                 'title'   => 'Config error.',
                 'message' => "Disk [$disk] not configured, please add a disk config in `config/filesystems.php`.",
@@ -127,7 +128,7 @@ trait UploadField
     /**
      * Specify the directory and name for upload file.
      *
-     * @param string $directory
+     * @param string      $directory
      * @param null|string $name
      *
      * @return $this
@@ -236,7 +237,7 @@ trait UploadField
     {
         $this->renameIfExists($file);
 
-        $target = $this->getDirectory() . '/' . $this->name;
+        $target = $this->getDirectory().'/'.$this->name;
 
         $this->storage->put($target, file_get_contents($file->getRealPath()));
 
@@ -270,7 +271,7 @@ trait UploadField
             return $path;
         }
 
-        return rtrim(config('admin.upload.host'), '/') . '/' . trim($path, '/');
+        return rtrim(config('admin.upload.host'), '/').'/'.trim($path, '/');
     }
 
     /**


### PR DESCRIPTION
当用户在执行options方法时,设置的配置文件会被默认配置覆盖.像这样:
```
$form->image("logo", "logo")->options(["initialCaption"=>"abc.jpg"]);
```
修复此问题.