### PR TITLE
Multiselect/checkbox save as string feature fix

### DIFF
--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -78,6 +78,7 @@ class MultipleSelect extends Select
     public function prepare(array $value)
     {
         $value = array_filter($value);
+
         return $this->isRelation() ? $value : implode(',', $value);
     }
 

--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -80,7 +80,7 @@ class MultipleSelect extends Select
         $value = array_filter($value);
         return $this->isRelation() ? $value : implode(',', $value);
     }
-    
+
     /**
      * @return bool
      */

--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -85,7 +85,7 @@ class MultipleSelect extends Select
     /**
      * @return bool
      */
-    protected function isRelation(): bool
+    protected function isRelation()
     {
         return method_exists($this->form->model(), $this->column)
             && ($relation = $this->form->model()->{$this->column}()) instanceof BelongsToMany;

--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -26,10 +26,9 @@ class MultipleSelect extends Select
             return $this->otherKey;
         }
 
-        if (method_exists($this->form->model(), $this->column) &&
-            ($relation = $this->form->model()->{$this->column}()) instanceof BelongsToMany
-        ) {
+        if ($this->isRelation()) {
             /* @var BelongsToMany $relation */
+            $relation = $this->form->model()->{$this->column}();
             $fullKey = $relation->getOtherKey();
 
             return $this->otherKey = substr($fullKey, strpos($fullKey, '.') + 1);
@@ -78,6 +77,16 @@ class MultipleSelect extends Select
 
     public function prepare(array $value)
     {
-        return array_filter($value);
+        $value = array_filter($value);
+        return $this->isRelation() ? $value : implode(',', $value);
+    }
+    
+    /**
+     * @return bool
+     */
+    protected function isRelation(): bool
+    {
+        return method_exists($this->form->model(), $this->column)
+            && ($relation = $this->form->model()->{$this->column}()) instanceof BelongsToMany;
     }
 }


### PR DESCRIPTION
The documentation states multiselect and checkbox can save as string, but it doesn't work.

Updated the prepare function to check if it's a relation or not and save accordingly