### PR TITLE
add AutoPermission middleware.

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -255,7 +255,7 @@ class Admin
         ];
 
         Route::group($attributes, function ($router) {
-            $attributes = ['middleware' => 'admin.permission:allow,administrator'];
+            $attributes = ['middleware' => ['admin.permission:allow,administrator','admin.auto_permission']];
 
             /* @var \Illuminate\Routing\Router $router */
             $router->group($attributes, function ($router) {
@@ -278,7 +278,7 @@ class Admin
     {
         $attributes = array_merge([
             'prefix'     => trim(config('admin.prefix'), '/').'/helpers',
-            'middleware' => ['web', 'admin'],
+            'middleware' => ['web', 'admin','admin.auto_permission'],
         ], $attributes);
 
         Route::group($attributes, function ($router) {

--- a/src/Middleware/AutoPermissionMiddleware.php
+++ b/src/Middleware/AutoPermissionMiddleware.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: never615
+ * Date: 10/03/2017
+ * Time: 8:36 PM
+ *
+ * You need set permission's slug by routeName or url( auth/roles of https://xxx.com/admin/auth/roles )
+ */
+namespace Encore\Admin\Middleware;
+
+use Closure;
+use Encore\Admin\Auth\Database\Permission;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class AutoPermissionMiddleware
+{
+    protected $except = [
+    ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param         $request
+     * @param Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+
+        $currentUrl = $request->path();
+        $currentUrl = substr($currentUrl, 6);  //admin
+        $currentRouteName = Route::currentRouteName();
+
+        if (Auth::guard("admin")->user()->isAdministrator()) {
+            //pass
+            return $next($request);
+        } else {
+            $permission = Permission::where('slug', $currentUrl)->orWhere('slug', $currentRouteName)->first();
+            if ($permission) {
+                if (Auth::guard("admin")->user()->can($permission->slug)) {
+                    //pass
+                    return $next($request);
+                } else {
+                    //denied
+                    throw new AccessDeniedHttpException(trans("errors.deny"));
+                }
+            } else {
+                //Does not have to create this permission.
+                return $next($request);
+            }
+        }
+    }
+}

--- a/src/Providers/AdminServiceProvider.php
+++ b/src/Providers/AdminServiceProvider.php
@@ -29,6 +29,7 @@ class AdminServiceProvider extends ServiceProvider
         'admin.log'         => \Encore\Admin\Middleware\OperationLog::class,
         'admin.permission'  => \Encore\Admin\Middleware\PermissionMiddleware::class,
         'admin.bootstrap'   => \Encore\Admin\Middleware\BootstrapMiddleware::class,
+        'admin.auto_permission'=>\Encore\Admin\Middleware\AutoPermissionMiddleware::class
     ];
 
     /**


### PR DESCRIPTION
自动根据访问路由和当前用户拥有的权限进行校验.
权限标识需要设置为路由名或者地址中admin/之后的参数.
* 管理员直接通过;
* 没有创建相关权限直接通过;
* 如果访问的路由在权限管理中设置了权限,则会根据访问用户拥有的权限进行校验.