### PR TITLE
option to draw checkboxes inline (default) or stacked

### DIFF
--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class Checkbox extends MultipleSelect
 {
+    protected $inline = true;
+
     protected static $css = [
         '/packages/admin/AdminLTE/plugins/iCheck/all.css',
     ];
@@ -33,12 +35,29 @@ class Checkbox extends MultipleSelect
     }
 
     /**
+     * Draw inline checkboxes
+     *
+     */
+    public function inline()
+    {
+        $this->inline = true;
+    }
+
+    /**
+     * Draw stacked checkboxes
+     */
+    public function stacked()
+    {
+        $this->inline = false;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function render()
     {
         $this->script = "$('{$this->getElementClassSelector()}').iCheck({checkboxClass:'icheckbox_minimal-blue'});";
 
-        return parent::render();
+        return parent::render()->with('inline', $this->inline);
     }
 }

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -35,8 +35,7 @@ class Checkbox extends MultipleSelect
     }
 
     /**
-     * Draw inline checkboxes
-     *
+     * Draw inline checkboxes.
      */
     public function inline()
     {
@@ -44,7 +43,7 @@ class Checkbox extends MultipleSelect
     }
 
     /**
-     * Draw stacked checkboxes
+     * Draw stacked checkboxes.
      */
     public function stacked()
     {

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -36,18 +36,26 @@ class Checkbox extends MultipleSelect
 
     /**
      * Draw inline checkboxes.
+     *
+     * @return $this
      */
     public function inline()
     {
         $this->inline = true;
+
+        return $this;
     }
 
     /**
      * Draw stacked checkboxes.
+     *
+     * @return $this
      */
     public function stacked()
     {
         $this->inline = false;
+
+        return $this;
     }
 
     /**

--- a/views/form/checkbox.blade.php
+++ b/views/form/checkbox.blade.php
@@ -6,13 +6,13 @@
 
         @include('admin::form.error')
 
-        <div class="checkbox">
-            @foreach($options as $option => $label)
-            <label>
+        @foreach($options as $option => $label)
+            @if(!$inline)<div class="checkbox">@endif
+            <label @if($inline)class="checkbox-inline"@endif>
                 <input type="checkbox" name="{{$name}}[]" value="{{$option}}" class="{{$class}}" {{ in_array($option, (array)old($column, $value))?'checked':'' }} {!! $attributes !!} />&nbsp;{{$label}}&nbsp;&nbsp;
             </label>
-            @endforeach
-        </div>
+            @if(!$inline)</div>@endif
+        @endforeach
 
         <input type="hidden" name="{{$name}}[]">
 


### PR DESCRIPTION
Stacked checkboxes make it easier to draw a tree menu for example

In my example, the options get indented with `&nbsp;` to create a tree like menu.

`$form->checkbox('categories')->options(...)->stacked();`
<img width="297" alt="screen shot 2017-03-13 at 11 20 55" src="https://cloud.githubusercontent.com/assets/5647964/23850306/2491c26c-07df-11e7-9b50-bd457008fc34.png">
