### PR TITLE
演示ajaxLoad()和不用通过option设置默认值

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -166,7 +166,7 @@ class Admin
     public static function script($script = '')
     {
         if (!empty($script)) {
-            self::$script = array_merge(self::$script, (array) $script);
+            self::$script = array_merge( (array) $script,self::$script);
 
             return;
         }

--- a/src/Form.php
+++ b/src/Form.php
@@ -14,7 +14,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Input;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Validator;
@@ -313,13 +312,11 @@ class Form
             return back()->withInput()->withErrors($validationMessages);
         }
 
-
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
 
         DB::transaction(function () {
-            Log::info($this->updates);
             $inserts = $this->prepareInsert($this->updates);
 
             foreach ($inserts as $column => $value) {
@@ -484,7 +481,7 @@ class Form
             ]);
         }
 
-//        /* @var Model $this->model */
+        /* @var Model $this->model */
         $this->model = $this->model->with($this->getRelations())->findOrFail($id);
 
         $this->setFieldOriginalValue();
@@ -499,13 +496,7 @@ class Form
         }
 
         DB::transaction(function () {
-            Log::info("111");
-
-            Log::info($this->updates);
-
             $updates = $this->prepareUpdate($this->updates);
-            Log::info($updates);
-
 
             foreach ($updates as $column => $value) {
                 /* @var Model $this->model */
@@ -705,7 +696,7 @@ class Form
                 $value = $field->prepare($value);
             }
 
-            if ($value==null||$value != $field->original()) {
+            if ($value != $field->original()) {
                 if (is_array($columns)) {
                     foreach ($columns as $name => $column) {
                         array_set($prepared, $column, $value[$name]);

--- a/src/Form.php
+++ b/src/Form.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Validator;
@@ -312,11 +313,13 @@ class Form
             return back()->withInput()->withErrors($validationMessages);
         }
 
+
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
 
         DB::transaction(function () {
+            Log::info($this->updates);
             $inserts = $this->prepareInsert($this->updates);
 
             foreach ($inserts as $column => $value) {
@@ -481,7 +484,7 @@ class Form
             ]);
         }
 
-        /* @var Model $this->model */
+//        /* @var Model $this->model */
         $this->model = $this->model->with($this->getRelations())->findOrFail($id);
 
         $this->setFieldOriginalValue();
@@ -496,7 +499,13 @@ class Form
         }
 
         DB::transaction(function () {
+            Log::info("111");
+
+            Log::info($this->updates);
+
             $updates = $this->prepareUpdate($this->updates);
+            Log::info($updates);
+
 
             foreach ($updates as $column => $value) {
                 /* @var Model $this->model */
@@ -696,7 +705,7 @@ class Form
                 $value = $field->prepare($value);
             }
 
-            if ($value != $field->original()) {
+            if ($value==null||$value != $field->original()) {
                 if (is_array($columns)) {
                     foreach ($columns as $name => $column) {
                         array_set($prepared, $column, $value[$name]);


### PR DESCRIPTION
演示 https://github.com/z-song/laravel-admin/issues/599

使用:
```
 $form->select("card_couponable_type", "所属类型")
            ->rules("required")
            ->options(SelectConstants::BELONG_TYPE);

$form->select("card_couponable_id", "所属")->ajaxLoad('card_couponable_type', data_source_url('ajax_load'));
```
默认值自动加载:
![screen shot 2017-03-16 at 7 48 09 pm](https://cloud.githubusercontent.com/assets/9959927/23994800/8b82c7a6-0a81-11e7-9fc5-f792558f8f20.png)

响应处理:  
获取默认值的请求默认是通过请求参数id来获取.
```
if (! is_null($id)) {
                    return Shop::select(DB::raw("id,name as text"))->findOrFail($id);
} else {
                    return Shop::select(DB::raw("id,name as text"))
                        ->where('name', '~*', "$q")
                        ->paginate(null, ['id', 'text']);
}
```
* 把默认值通过option这一操作,通过底层库的代码和controller中响应数据源的代码来分担.好处是:同一个数据源不用每次使用都写重复代码了.option中设置默认值的代码要写好几行.
* 第一点就是优化的核心,然后只是写了一个ajaxLoad用来实现load操作的分页请求数据.


