### PR TITLE
修改在注册guard时使用的模型

### DIFF
--- a/src/Providers/AdminServiceProvider.php
+++ b/src/Providers/AdminServiceProvider.php
@@ -98,7 +98,7 @@ class AdminServiceProvider extends ServiceProvider
             'auth.guards.admin.driver'    => 'session',
             'auth.guards.admin.provider'  => 'admin',
             'auth.providers.admin.driver' => 'eloquent',
-            'auth.providers.admin.model'  => 'Encore\Admin\Auth\Database\Administrator',
+            'auth.providers.admin.model'  => config('admin.database.users_model'),
         ]);
     }
 


### PR DESCRIPTION
现在是固定使用 `Encore\Admin\Auth\Database\Administrator`, 
但是如果我自定义了一个模型继承了它并扩展了功能, 
而且已经在在 `config/admin.php` 里自定义了 `database.users_model`,
这时候通过 `Admin::user()` 获取到的依旧是原来的 `Encore\Admin\Auth\Database\Administrator`.