### PR TITLE
add hiddenInCreate() in Form.

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -822,6 +822,19 @@ class Form
     }
 
     /**
+     * Hide fields to create.
+     *
+     * @param string|array $fields
+     *
+     * @return $this
+     */
+    public function hiddenInCreate($fields)
+    {
+        $this->builder->hiddenInCreate($fields);
+        return $this;
+    }
+
+    /**
      * @param array        $data
      * @param string|array $columns
      *

--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -39,6 +39,13 @@ class Builder
     protected $fields;
 
     /**
+     * Ignored creating fields.
+     *
+     * @var array
+     */
+    protected $ignoredCreateFields = [];
+
+    /**
      * @var array
      */
     protected $options = [
@@ -470,9 +477,23 @@ EOT;
             $this->form->model()->getUpdatedAtColumn(),
         ];
 
+        $reservedColumns=array_merge($reservedColumns,$this->ignoredCreateFields);
+
         $this->fields = $this->fields()->reject(function (Field $field) use ($reservedColumns) {
             return in_array($field->column(), $reservedColumns);
         });
+    }
+
+    /**
+     * Hide fields to create.
+     *
+     * @param string|array $fields
+     *
+     * @return $this
+     */
+    public function hiddenInCreate($fields)
+    {
+        $this->ignoredCreateFields = array_merge($this->ignoredCreateFields, (array)$fields);
     }
 
     /**


### PR DESCRIPTION
**方法作用:** 在创建页隐藏相应的条目.

**创建方法原因:** 一些字段在创建页不需要显示出来,在编辑/详情页需要显示.

**调用演示:**
`        $form->hiddenInCreate(['published_at','approved_at']);
`

