### PR TITLE
[Add Feature]: 客制化 Form 表单元素的行列布局

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -169,6 +169,41 @@ class Field implements Renderable
     ];
 
     /**
+     * Start flg for prepending row.
+     *
+     * @var bool
+     */
+    protected $prependRowStart = false;
+
+    /**
+     * End flg for prepending row.
+     *
+     * @var bool
+     */
+    protected $prependRowEnd = false;
+
+    /**
+     * Flg for prepending column.
+     *
+     * @var bool
+     */
+    protected $inPrependColumn = false;
+
+    /**
+     * Coloumn width for prepending parent column.
+     *
+     * @var int
+     */
+    protected $prependColumnWidth = -1;
+
+    /**
+     * Coloumn offset for prepending parent column.
+     *
+     * @var int
+     */
+    protected $prependColumnOffset = -1;
+
+    /**
      * Field constructor.
      *
      * @param $column
@@ -839,6 +874,110 @@ class Field implements Renderable
     {
         if ($method === 'default') {
             return $this->setDefault(array_get($arguments, 0));
+        }
+    }
+
+    /**
+     * Set the start/end flg for prepending row.
+     *
+     * @return $this
+     */
+    public function prependRowStart() {
+        $this -> prependRowStart = true;
+        $this -> prependRowEnd = false;
+        return $this;
+    }
+
+    /**
+     * Set the start/end flg for prepending row.
+     *
+     * @return $this
+     */
+    public function prependRowEnd() {
+        $this -> prependRowStart = false;
+        $this -> prependRowEnd = true;
+        return $this;
+    }
+
+    /**
+     * Get the start flg for prepending row.
+     *
+     * @return bool
+     */
+    public function getPrependRowStart() {
+        return $this -> prependRowStart;
+    }
+
+    /**
+     * Get the end flg for prepending row.
+     *
+     * @return bool
+     */
+    public function getPrependRowEnd() {
+        return $this -> prependRowEnd;
+    }
+
+    /**
+     * Start prepending row.
+     */
+    public function startRow()
+    {
+        echo '<div class="row">';
+    }
+
+    /**
+     * End prepending column.
+     */
+    public function endRow()
+    {
+        echo '</div>';
+    }
+
+    /**
+     * Set the flg/column-width/column-offset for prepending column.
+     *
+     * @return $this
+     */
+    public function prependColumn($width = -1, $offset = -1) {
+        $this -> inPrependColumn = true;
+        $this -> prependColumnWidth = $width;
+        $this -> prependColumnOffset = $offset;
+        return $this;
+    }
+
+    /**
+     * Start prepending column.
+     */
+    public function startColumnOrNot()
+    {
+        if ($this -> inPrependColumn) {
+            $html = '<div class="';
+            if ($this->prependColumnWidth > 0) {
+                $html .= " col-md-{$this->prependColumnWidth}";
+            }
+            if ($this->prependColumnOffset > 0) {
+                $html .= " col-md-offset-{$this->prependColumnOffset}";
+            }
+            if ($this->prependColumnWidth > 0 || $this->prependColumnOffset > 0) {
+                $html .= '">';
+                echo $html;
+            } else {
+                echo '<div>';
+            }
+        } else {
+           echo ''; 
+        }
+    }
+
+    /**
+     * End prepending column.
+     */
+    public function endColumnOrNot()
+    {
+        if ($this -> inPrependColumn) {
+            echo '</div>';
+        } else {
+            echo ''; 
         }
     }
 }

--- a/views/form.blade.php
+++ b/views/form.blade.php
@@ -14,11 +14,21 @@
             @if(!$tabObj->isEmpty())
                 @include('admin::form.tab', compact('tabObj'))
             @else
-                <div class="fields-group">
-                    @foreach($form->fields() as $field)
-                        {!! $field->render() !!}
-                    @endforeach
-                </div>
+            <div class="fields-group">
+                @foreach($form->fields() as $field)
+                    @if($field -> getPrependRowStart() && !$field -> getPrependRowEnd())
+                        {!! $field->startRow() !!}
+                    @endif
+
+                    {!! $field->startColumnOrNot() !!}
+                    {!! $field->render() !!}
+                    {!! $field->endColumnOrNot() !!}
+
+                    @if(!$field -> getPrependRowStart() && $field -> getPrependRowEnd())
+                        {!! $field->endRow() !!}
+                    @endif
+                @endforeach
+            </div>
             @endif
 
         </div>


### PR DESCRIPTION
由于想在 `Form` 组件中客制化 row/column 布局，故此修改。
如果已实现该想法和功能的话请关闭此 pull request 。

###  用例：
1. 在想要被 `<div class="row"></div>` 包围的 Field 元件的渲染闭包中，调用函数`#prependRowStart()`来标记起始元素，调用函数`#prependRowEnd()`来标记结束元素。( 请配对使用 )

> $form->text('username', trans('admin::lang.username'))->**prependRowStart()**->rules('required');
> $form->text('name', trans('admin::lang.name'))->**prependRowEnd()**->rules('required');

2. 在想要被 `<div class="col-md-x col-md-offset-x"></div>` 包围的 Field 元件的渲染闭包中，调用函数`#prependColumn(int, int)`。第一个参数为'col-sm-x'的值，第二个参数为`col-md-offset-x`的值。
( Form 组件默认参数下 form的布局为`form-horizontal`，故不加 row 也无妨，如果修改了布局为`grid` 等的话，记得添加 row)

> $form->text('username', trans('admin::lang.username'))->**prependColumn(4,1)**->rules('required');
> $form->text('name', trans('admin::lang.name'))->**prependColumn(4,1)**->rules('required');
