### PR TITLE
Ilike filter for postgreSQL

### DIFF
--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -13,6 +13,7 @@ use ReflectionClass;
  *
  * @method Filter     equal($column, $label = '')
  * @method Filter     like($column, $label = '')
+ * @method Filter     ilike($column, $label = '')
  * @method Filter     gt($column, $label = '')
  * @method Filter     lt($column, $label = '')
  * @method Filter     between($column, $label = '')
@@ -33,7 +34,7 @@ class Filter
     /**
      * @var array
      */
-    protected $supports = ['equal', 'is', 'like', 'gt', 'lt', 'between', 'where'];
+    protected $supports = ['equal', 'is', 'ilike', 'like', 'gt', 'lt', 'between', 'where'];
 
     /**
      * If use a modal to hold the filters.

--- a/src/Grid/Filter/Ilike.php
+++ b/src/Grid/Filter/Ilike.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Encore\Admin\Grid\Filter;
+
+class Ilike extends AbstractFilter
+{
+    /**
+     * Get condition of this filter.
+     *
+     * @param array $inputs
+     *
+     * @return array|mixed|void
+     */
+    public function condition($inputs)
+    {
+        $value = array_get($inputs, $this->column);
+
+        if (is_array($value)) {
+            $value = array_filter($value);
+        }
+
+        if (is_null($value) || empty($value)) {
+            return;
+        }
+
+        $this->value = $value;
+
+        return $this->buildCondition($this->column, 'ilike', "%{$this->value}%");
+    }
+}

--- a/views/filter/ilike.blade.php
+++ b/views/filter/ilike.blade.php
@@ -1,0 +1,4 @@
+<div class="input-group input-group-sm">
+    <span class="input-group-addon"><strong>{{$label}}</strong></span>
+    @include('admin::filter.' . $field->name())
+</div>


### PR DESCRIPTION
In PostgreSQL you can run this: `WHERE name ILIKE '%john%'` for case-INsesitive LIKE. This pull request adds it:

```php
$grid->filter(function (Filter $filter) {
    $filter->ilike('contact.name');
});
```