### PR TITLE
Make the root parentID configurable.

### DIFF
--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -29,6 +29,11 @@ trait ModelTree
     protected $orderColumn = 'order';
 
     /**
+     * @var integer|null
+     */
+    protected $rootID = 0;
+
+    /**
      * @var \Closure
      */
     protected $queryCallback;
@@ -112,6 +117,26 @@ trait ModelTree
     }
 
     /**
+     * Get value for ID of root.
+     *
+     * @return integer|null
+     */
+    public function getRootID()
+    {
+        return $this->rootID;
+    }
+
+    /**
+     * Set value for ID of root.
+     *
+     * @param integer|null $rootID
+     */
+    public function setRootID($rootID)
+    {
+        $this->rootID = $rootID;
+    }
+
+    /**
      * Set query callback to model.
      *
      * @param \Closure|null $query
@@ -132,7 +157,7 @@ trait ModelTree
      */
     public function toTree()
     {
-        return $this->buildNestedArray();
+        return $this->buildNestedArray([], $this->rootID);
     }
 
     /**
@@ -174,7 +199,7 @@ trait ModelTree
     public function allNodes()
     {
         $orderColumn = DB::getQueryGrammar()->wrap($this->orderColumn);
-        $byOrder = $orderColumn.' = 0,'.$orderColumn;
+        $byOrder = $orderColumn.' = '.($this->rootID == null ? 'null' : $this->rootID).','.$orderColumn;
 
         $self = new static();
 
@@ -302,7 +327,7 @@ trait ModelTree
 
                 Request::offsetUnset('_order');
 
-                static::tree()->saveOrder($order);
+                static::tree()->saveOrder($order, $branch->getRootID());
 
                 return false;
             }

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -158,7 +158,7 @@ class Tree implements Renderable
             throw new \InvalidArgumentException(json_last_error_msg());
         }
 
-        $this->model->saveOrder($tree);
+        $this->model->saveOrder($tree, $this->model->getRootID());
 
         return true;
     }


### PR DESCRIPTION
When using ModelTree, I want to save the parentID of  top level nodes as NULL and not as 0 . This pull request makes this rootID configurable. So in the model which has ModelTree trait, just call
```
$this->setRootID(null)
```
All parent_id of the nodes in the top level will have the values `null`