### PR TITLE
Allow to redefine mysql host

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,7 +29,7 @@ class TestCase extends BaseTestCase
         parent::setUp();
 
         $this->app['config']->set('database.default', 'mysql');
-        $this->app['config']->set('database.connections.mysql.host', 'localhost');
+        $this->app['config']->set('database.connections.mysql.host', env('MYSQL_HOST', 'localhost'));
         $this->app['config']->set('database.connections.mysql.database', 'laravel_admin');
         $this->app['config']->set('database.connections.mysql.username', 'root');
         $this->app['config']->set('database.connections.mysql.password', '');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -107,5 +107,4 @@ class TestCase extends BaseTestCase
 
         return $class;
     }
-
 }


### PR DESCRIPTION
On Mac if you try to run tests - they will fail, because tests try to connect to `localhost` and on Mac for some reason you get: `PDOException: SQLSTATE[HY000] [2002] No such file or directory`

Stackoverflow suggests changing it to `127.0.0.1` - that works: http://stackoverflow.com/a/22927341/37141 

So, this pull request allows me to run tests as `MYSQL_HOST=127.0.0.1 vendor/bin/phpunit` (otherwise tests don't run at all) and it doesn't change anything for already existing code.