### PR TITLE
pass along value in callback of `Html->render()`

### DIFF
--- a/src/Form/Field/Html.php
+++ b/src/Form/Field/Html.php
@@ -32,6 +32,14 @@ class Html extends Field
     }
 
     /**
+     * Fill in the data.
+     */
+    public function fill($data)
+    {
+        $this->value = $data;
+    }
+
+    /**
      * Render html field.
      *
      * @return string
@@ -41,7 +49,7 @@ class Html extends Field
         if ($this->html instanceof \Closure) {
             $callback = $this->html->bindTo($this->form->model());
 
-            $this->html = call_user_func($callback, $this->form);
+            $this->html = call_user_func($callback, $this->form, $this->value);
         }
 
         return <<<EOT


### PR DESCRIPTION
Currently there is no option to get to the data in the html field component in a nested form. In a normal form you can use the '$this->model()' to get to the data, but in a nested form you get the parent model, and not the relation one

Currently in a hasMany form:
```php
$nestedForm->html(
    function ($form) {
        $id = $form->model()->id; // this is the parent model, not the relation one
        return '<a href="link?id='.$id.'" class="btn btn-default">Do something</a>';
     }
);
```
suggestion:
```php
$nestedForm->html(
    function ($form, $data) {
        $id = array_get($data, 'id'); // this is the id of the hasmany relation model
        return '<a href="link?id='.$id.'" class="btn btn-default">Do something</a>';
    }
);
```