### PR TITLE
fix form tags submit error

### DIFF
--- a/src/Form/Field/Tags.php
+++ b/src/Form/Field/Tags.php
@@ -29,7 +29,11 @@ class Tags extends Field
 
     public function prepare($value)
     {
-        return array_filter($value);
+        if (is_array($value) && !Arr::isAssoc($value)) {
+            $value = implode(',', $value);
+        }
+
+        return $value;
     }
 
     public function render()


### PR DESCRIPTION
Form去掉formatValueBeforeSave逻辑之后, 在表单提交时 tags的数据在insert和update的时候都会使用直接array , 触发 `Array to string conversion`错误.
此处将原来的formatValueBeforeSave方法的逻辑加入tags的默认prepare中