### PR TITLE
fix form tags submit error

### DIFF
--- a/src/Form/Field/Tags.php
+++ b/src/Form/Field/Tags.php
@@ -3,6 +3,7 @@
 namespace Encore\Admin\Form\Field;
 
 use Encore\Admin\Form\Field;
+use Illuminate\Support\Arr;
 
 class Tags extends Field
 {
@@ -29,7 +30,11 @@ class Tags extends Field
 
     public function prepare($value)
     {
-        return array_filter($value);
+        if (is_array($value) && !Arr::isAssoc($value)) {
+            $value = implode(',', array_filter($value));
+        }
+
+        return $value;
     }
 
     public function render()


### PR DESCRIPTION
Form去掉formatValueBeforeSave逻辑之后, 在表单提交时 tags的数据在insert和update的时候都会使用直接array , 触发 Array to string conversion错误.
此处将原来的formatValueBeforeSave方法的逻辑加入tags的默认prepare中