### PR TITLE
Hardcoded IDs in tests and test speed-up

### DIFF
--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -105,6 +105,11 @@ class Column
     protected static $htmlAttributes = [];
 
     /**
+     * @var
+     */
+    protected static $model;
+
+    /**
      * @param string $name
      * @param string $label
      */

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -145,6 +145,20 @@ class Column
     public function setGrid(Grid $grid)
     {
         $this->grid = $grid;
+
+        $this->setModel($grid->model()->eloquent());
+    }
+
+    /**
+     * Set model for column.
+     *
+     * @param $model
+     */
+    public function setModel($model)
+    {
+        if (is_null(static::$model) && ($model instanceof Model)) {
+            static::$model = $model->newInstance();
+        }
     }
 
     /**
@@ -332,7 +346,7 @@ class Column
     {
         $originalRow = static::$originalGridData[$key];
 
-        return $callback->bindTo($originalRow);
+        return $callback->bindTo(static::$model->newFromBuilder($originalRow));
     }
 
     /**
@@ -347,11 +361,9 @@ class Column
         foreach ($data as $key => &$row) {
             $this->original = $value = array_get($row, $this->name);
 
-            if (!($value instanceof Model)) {
-                $value = $this->htmlEntityEncode($value);
-            }
+            $value = $this->htmlEntityEncode($value);
 
-            $row->{$this->name} = $value;
+            array_set($row, $this->name, $value);
 
             if ($this->isDefinedColumn()) {
                 $this->useDefinedColumn();
@@ -359,7 +371,7 @@ class Column
 
             if ($this->hasDisplayCallbacks()) {
                 $value = $this->callDisplayCallbacks($this->original, $key);
-                $row->{$this->name} = $value;
+                array_set($row, $this->name, $value);
             }
         }
 

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -183,7 +183,7 @@ class Model
                 $collection = call_user_func($this->collectionCallback, $collection);
             }
 
-            $this->data = $collection->all();
+            $this->data = $collection->toArray();
         }
 
         return $this->data;

--- a/src/Grid/Row.php
+++ b/src/Grid/Row.php
@@ -12,11 +12,11 @@ class Row
     protected $number;
 
     /**
-     * Row model.
+     * Row data.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var
      */
-    protected $model;
+    protected $data;
 
     /**
      * Attributes of row.
@@ -29,13 +29,13 @@ class Row
      * Constructor.
      *
      * @param $number
-     * @param $model
+     * @param $data
      */
-    public function __construct($number, $model)
+    public function __construct($number, $data)
     {
         $this->number = $number;
 
-        $this->model = $model;
+        $this->data = $data;
     }
 
     /**
@@ -134,13 +134,13 @@ class Row
     }
 
     /**
-     * Get model of this row.
+     * Get data of this row.
      *
      * @return mixed
      */
     public function model()
     {
-        return $this->model;
+        return $this->data;
     }
 
     /**
@@ -152,7 +152,7 @@ class Row
      */
     public function __get($attr)
     {
-        return $this->model->getAttribute($attr);
+        return array_get($this->data, $attr);
     }
 
     /**
@@ -166,7 +166,7 @@ class Row
     public function column($name, $value = null)
     {
         if (is_null($value)) {
-            $column = $this->model->getAttribute($name);
+            $column = array_get($this->data, $name);
 
             return $this->dump($column);
         }
@@ -176,7 +176,7 @@ class Row
             $value = $value($this->column($name));
         }
 
-        $this->model->{$name} = $value;
+        array_set($this->data, $name, $value);
 
         return $this;
     }
@@ -190,10 +190,6 @@ class Row
      */
     protected function dump($var)
     {
-        if (method_exists($var, '__toString')) {
-            return $var->__toString();
-        }
-
         if (!is_scalar($var)) {
             return '<pre>'.var_export($var, true).'</pre>';
         }

--- a/tests/FileUploadTest.php
+++ b/tests/FileUploadTest.php
@@ -78,7 +78,7 @@ class FileUploadTest extends TestCase
 
         $old = FileModel::first();
 
-        $this->visit('admin/files/' . $old->id . '/edit')
+        $this->visit('admin/files/'.$old->id.'/edit')
             ->see('ID')
             ->see('Created At')
             ->see('Updated At')
@@ -122,7 +122,7 @@ class FileUploadTest extends TestCase
 
         $files = FileModel::first()->toArray();
 
-        $this->delete('admin/files/' . $files['id'])
+        $this->delete('admin/files/'.$files['id'])
             ->dontSeeInDatabase('test_files', ['id' => $files['id']]);
 
         foreach (range(1, 6) as $index) {

--- a/tests/FileUploadTest.php
+++ b/tests/FileUploadTest.php
@@ -78,7 +78,7 @@ class FileUploadTest extends TestCase
 
         $old = FileModel::first();
 
-        $this->visit('admin/files/1/edit')
+        $this->visit('admin/files/' . $old->id . '/edit')
             ->see('ID')
             ->see('Created At')
             ->see('Updated At')
@@ -122,8 +122,8 @@ class FileUploadTest extends TestCase
 
         $files = FileModel::first()->toArray();
 
-        $this->delete('admin/files/1')
-            ->dontSeeInDatabase('test_files', ['id' => 1]);
+        $this->delete('admin/files/' . $files['id'])
+            ->dontSeeInDatabase('test_files', ['id' => $files['id']]);
 
         foreach (range(1, 6) as $index) {
             $this->assertFileNotExists(public_path('upload/'.$files['file'.$index]));
@@ -141,10 +141,12 @@ class FileUploadTest extends TestCase
         $this->uploadFiles();
         $this->uploadFiles();
 
+        list($id1, $id2, $id3) = FileModel::take(3)->pluck('id')->toArray();
+
         $this->visit('admin/files')
-            ->seeInElement('td', 1)
-            ->seeInElement('td', 2)
-            ->seeInElement('td', 3);
+            ->seeInElement('td', $id1)
+            ->seeInElement('td', $id2)
+            ->seeInElement('td', $id3);
 
         $fi = new FilesystemIterator(public_path('upload/file'), FilesystemIterator::SKIP_DOTS);
 
@@ -152,14 +154,14 @@ class FileUploadTest extends TestCase
 
         $this->assertEquals(FileModel::count(), 3);
 
-        $this->delete('admin/files/1,2,3');
+        $this->delete(sprintf('admin/files/%d,%d,%d', $id1, $id2, $id3));
 
         $this->assertEquals(FileModel::count(), 0);
 
         $this->visit('admin/files')
-            ->dontSeeInElement('td', 1)
-            ->dontSeeInElement('td', 2)
-            ->dontSeeInElement('td', 3);
+            ->dontSeeInElement('td', $id1)
+            ->dontSeeInElement('td', $id2)
+            ->dontSeeInElement('td', $id3);
 
         $this->assertEquals(iterator_count($fi), 0);
     }

--- a/tests/ImageUploadTest.php
+++ b/tests/ImageUploadTest.php
@@ -149,7 +149,7 @@ class ImageUploadTest extends TestCase
         $this->visit('admin/images')
             ->seeInElement('td', $image['id']);
 
-        $this->delete('admin/images/' . $image['id'])
+        $this->delete('admin/images/'.$image['id'])
             ->dontSeeInDatabase('test_images', ['id' => $image['id']]);
 
         foreach (range(1, 6) as $index) {

--- a/tests/OperationLogTest.php
+++ b/tests/OperationLogTest.php
@@ -53,8 +53,8 @@ class OperationLogTest extends TestCase
 
         $id = OperationLog::first()->id;
 
-        $this->delete('admin/auth/logs/' . $id)
-            ->seeInDatabase($table, ['path' => 'admin/auth/logs/' . $id, 'method' => 'DELETE'])
+        $this->delete('admin/auth/logs/'.$id)
+            ->seeInDatabase($table, ['path' => 'admin/auth/logs/'.$id, 'method' => 'DELETE'])
             ->assertEquals(1, OperationLog::count());
     }
 
@@ -76,14 +76,14 @@ class OperationLogTest extends TestCase
 
         $ids = OperationLog::take(5)->pluck('id')->toArray();
 
-        $this->delete('admin/auth/logs/' . join(',', $ids))
+        $this->delete('admin/auth/logs/'.implode(',', $ids))
             ->notSeeInDatabase($table, ['path' => 'admin/auth/menu', 'method' => 'GET'])
             ->notSeeInDatabase($table, ['path' => 'admin/auth/users', 'method' => 'GET'])
             ->notSeeInDatabase($table, ['path' => 'admin/auth/permissions', 'method' => 'GET'])
             ->notSeeInDatabase($table, ['path' => 'admin/auth/roles', 'method' => 'GET'])
             ->notSeeInDatabase($table, ['path' => 'admin/auth/logs', 'method' => 'GET'])
 
-            ->seeInDatabase($table, ['path' => 'admin/auth/logs/' . join(',', $ids), 'method' => 'DELETE'])
+            ->seeInDatabase($table, ['path' => 'admin/auth/logs/'.implode(',', $ids), 'method' => 'DELETE'])
             ->assertEquals(1, OperationLog::count());
     }
 }

--- a/tests/OperationLogTest.php
+++ b/tests/OperationLogTest.php
@@ -51,8 +51,10 @@ class OperationLogTest extends TestCase
             ->seePageIs('admin/auth/logs')
             ->assertEquals(1, OperationLog::count());
 
-        $this->delete('admin/auth/logs/1')
-            ->seeInDatabase($table, ['path' => 'admin/auth/logs/1', 'method' => 'DELETE'])
+        $id = OperationLog::first()->id;
+
+        $this->delete('admin/auth/logs/' . $id)
+            ->seeInDatabase($table, ['path' => 'admin/auth/logs/' . $id, 'method' => 'DELETE'])
             ->assertEquals(1, OperationLog::count());
     }
 
@@ -72,14 +74,16 @@ class OperationLogTest extends TestCase
             ->seeInDatabase($table, ['path' => 'admin/auth/logs', 'method' => 'GET'])
             ->assertEquals(5, OperationLog::count());
 
-        $this->delete('admin/auth/logs/1,2,3,4,5')
+        $ids = OperationLog::take(5)->pluck('id')->toArray();
+
+        $this->delete('admin/auth/logs/' . join(',', $ids))
             ->notSeeInDatabase($table, ['path' => 'admin/auth/menu', 'method' => 'GET'])
             ->notSeeInDatabase($table, ['path' => 'admin/auth/users', 'method' => 'GET'])
             ->notSeeInDatabase($table, ['path' => 'admin/auth/permissions', 'method' => 'GET'])
             ->notSeeInDatabase($table, ['path' => 'admin/auth/roles', 'method' => 'GET'])
             ->notSeeInDatabase($table, ['path' => 'admin/auth/logs', 'method' => 'GET'])
 
-            ->seeInDatabase($table, ['path' => 'admin/auth/logs/1,2,3,4,5', 'method' => 'DELETE'])
+            ->seeInDatabase($table, ['path' => 'admin/auth/logs/' . join(',', $ids), 'method' => 'DELETE'])
             ->assertEquals(1, OperationLog::count());
     }
 }

--- a/tests/RolesTest.php
+++ b/tests/RolesTest.php
@@ -85,10 +85,10 @@ class RolesTest extends TestCase
 
         list($roleId1, $roleId2) = Role::take(2)->orderBy('id')->pluck('id')->toArray();
 
-        $this->delete('admin/auth/roles/' . $roleId2)
+        $this->delete('admin/auth/roles/'.$roleId2)
             ->assertEquals(1, Role::count());
 
-        $this->delete('admin/auth/roles/' . $roleId1)
+        $this->delete('admin/auth/roles/'.$roleId1)
             ->assertEquals(0, Role::count());
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,7 +40,9 @@ class TestCase extends BaseTestCase
         $this->app['config']->set('admin', require __DIR__.'/config/admin.php');
 
         if(self::$firstRun) {
-            $this->rollback();
+            if(Schema::hasTable('migrations')) {
+                $this->rollback();
+            }
 
             self::$firstRun = false;
             $this->artisan('vendor:publish');
@@ -50,10 +52,7 @@ class TestCase extends BaseTestCase
             $this->artisan('admin:install');
         }
 
-        //\DB::unprepared('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
-
-        \DB::beginTransaction();
-
+        DB::beginTransaction();
 
         \Encore\Admin\Facades\Admin::registerAuthRoutes();
 
@@ -68,7 +67,7 @@ class TestCase extends BaseTestCase
 
     public function tearDown()
     {
-        \DB::rollback();
+        DB::rollback();
 
         parent::tearDown();
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,8 +39,8 @@ class TestCase extends BaseTestCase
         $this->app['config']->set('filesystems', require __DIR__.'/config/filesystems.php');
         $this->app['config']->set('admin', require __DIR__.'/config/admin.php');
 
-        if(self::$firstRun) {
-            if(Schema::hasTable('migrations')) {
+        if (self::$firstRun) {
+            if (Schema::hasTable('migrations')) {
                 $this->rollback();
             }
 

--- a/tests/UserFormTest.php
+++ b/tests/UserFormTest.php
@@ -113,7 +113,7 @@ class UserFormTest extends TestCase
     {
         $this->seedsTable(10);
 
-        $id = rand(1, 10);
+        $id = UserModel::inRandomOrder()->first()->id;
 
         $user = UserModel::with('profile')->find($id);
 
@@ -141,7 +141,7 @@ class UserFormTest extends TestCase
     {
         $this->seedsTable(10);
 
-        $id = rand(1, 10);
+        $id = UserModel::inRandomOrder()->first()->id;
 
         $this->visit("admin/users/$id/edit")
             ->type('hello world', 'username')
@@ -160,7 +160,7 @@ class UserFormTest extends TestCase
     {
         $this->seedsTable(10);
 
-        $id = rand(1, 10);
+        $id = UserModel::inRandomOrder()->first()->id;
 
         $this->visit("admin/users/$id/edit")
             ->type('', 'email')

--- a/tests/UserGridTest.php
+++ b/tests/UserGridTest.php
@@ -101,11 +101,9 @@ class UserGridTest extends TestCase
         $this->assertCount(50, UserModel::all());
         $this->assertCount(50, ProfileModel::all());
 
-        $id = rand(1, 50);
+        $user = UserModel::inRandomOrder()->first();
 
-        $user = UserModel::find($id);
-
-        $this->visit('admin/users?id='.$id)
+        $this->visit('admin/users?id=' . $user->id)
             ->seeInElement('td', $user->username)
             ->seeInElement('td', $user->email)
             ->seeInElement('td', $user->mobile)
@@ -144,7 +142,7 @@ class UserGridTest extends TestCase
     {
         $this->seedsTable(50);
 
-        $user = UserModel::with('profile')->find(rand(1, 50));
+        $user = UserModel::inRandomOrder()->with('profile')->first();
 
         $this->visit('admin/users?email='.$user->email)
             ->seeInElement('td', $user->username)
@@ -164,7 +162,7 @@ class UserGridTest extends TestCase
     {
         $this->seedsTable(1);
 
-        $user = UserModel::with('profile')->find(1);
+        $user = UserModel::with('profile')->first();
 
         $this->visit('admin/users')
             ->seeInElement('th', 'Column1 not in table')

--- a/tests/UserGridTest.php
+++ b/tests/UserGridTest.php
@@ -103,7 +103,7 @@ class UserGridTest extends TestCase
 
         $user = UserModel::inRandomOrder()->first();
 
-        $this->visit('admin/users?id=' . $user->id)
+        $this->visit('admin/users?id='.$user->id)
             ->seeInElement('td', $user->username)
             ->seeInElement('td', $user->email)
             ->seeInElement('td', $user->mobile)


### PR DESCRIPTION
While hunting for problem in #627 - I've had to run tests many times and they take forever to run. I've profiled them and most of the time is spent on "migrate-rollback" cycle. So, I've changed it to run `migrate` only once at first start and then run each test in transaction, which is then rolled back.

The problem that I've immediately stumbled upon - was that tests have a lot of hardcoded ID's, like `find(rand(1,10))`, but with transactions - the AUTOINCREMENT is not reset, so I've had to change them to things like:

```
// previously: Model::find(rand(1,10))
Model::inRandomOrder()->take(10)->first()->id
```

which, does the same thing.

As a result - tests pass and they run 3-5 times faster on my machine (~1 minute, instead of 3-5 minutes).

As another result - with this fix tests on #627 pass without any weirdness that I wrote about here https://github.com/z-song/laravel-admin/pull/627#issuecomment-290132834