### PR TITLE
公开Filter的addFilter方法，可以自定义筛选条件

### DIFF
--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -112,7 +112,7 @@ class Filter
      *
      * @return AbstractFilter
      */
-    protected function addFilter(AbstractFilter $filter)
+    public function addFilter(AbstractFilter $filter)
     {
         return $this->filters[] = $filter;
     }


### PR DESCRIPTION
- 我在做筛选时，需要对多个字段来筛选，但是现在的筛选条件只能对自定的一个字段来筛选，但是现在filter也不支持自定义筛选；

- 如果将Filter的addFilter方法设置pulic，则可以支持自定义filter了

- 例如自定义如下

```php

class CustomerLike extends AbstractFilter
{
    protected $other_columns;

    protected $boolean;

    /**
     * AbstractFilter constructor.
     *
     * @param        $column
     * @param string $label
     */
    public function __construct($column, $label = '', $other_columns = [], $boolean = 'and')
    {
        parent::__construct($column, $label);

        $this->other_columns = $other_columns;
        $this->boolean = $boolean;
    }

    /**
     * Get condition of this filter.
     *
     * @param array $inputs
     *
     * @return array|mixed|void
     */
    public function condition($inputs)
    {
        $value = array_get($inputs, $this->column);

        if (is_array($value)) {
            $value = array_filter($value);
        }

        if (is_null($value) || empty($value)) {
            return;
        }

        $this->value = $value;

        $where = function ($query) {
            $this->other_columns[] = $this->column;
            foreach ($this->other_columns as $column) {
                $query->where($column, 'like', "%{$this->value}%", $this->boolean);
            }
        };

        return $this->buildCondition($where);
    }
}
```

- 使用方法：

```php
$grid->filter(function (Grid\Filter $filter) {
    $filter = new CustomerLike('name', '游戏名称', ['pinyin', 'py'], 'or');
    $filter->addFilter($filter);
});
```