### PR TITLE
将Administrator、Role、Permission、Menu的mode类独立出来，采用admin.php中的配置

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -3,7 +3,6 @@
 namespace Encore\Admin;
 
 use Closure;
-use Encore\Admin\Auth\Database\Menu;
 use Encore\Admin\Layout\Content;
 use Encore\Admin\Widgets\Navbar;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
@@ -199,7 +198,9 @@ class Admin
      */
     public function menu()
     {
-        return (new Menu())->toTree();
+        $menu_model = config('admin.database.menu_model');
+
+        return (new $menu_model())->toTree();
     }
 
     /**

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -2,7 +2,6 @@
 
 namespace Encore\Admin\Controllers;
 
-use Encore\Admin\Auth\Database\Administrator;
 use Encore\Admin\Facades\Admin;
 use Encore\Admin\Form;
 use Encore\Admin\Layout\Content;
@@ -99,7 +98,7 @@ class AuthController extends Controller
      */
     protected function settingForm()
     {
-        return Administrator::form(function (Form $form) {
+        return config('admin.database.users_model')::form(function (Form $form) {
             $form->display('username', trans('admin::lang.username'));
             $form->text('name', trans('admin::lang.name'))->rules('required');
             $form->image('avatar', trans('admin::lang.avatar'));

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -98,7 +98,9 @@ class AuthController extends Controller
      */
     protected function settingForm()
     {
-        return config('admin.database.users_model')::form(function (Form $form) {
+        $model = config('admin.database.users_model');
+
+        return $model::form(function (Form $form) {
             $form->display('username', trans('admin::lang.username'));
             $form->text('name', trans('admin::lang.name'))->rules('required');
             $form->image('avatar', trans('admin::lang.avatar'));

--- a/src/Controllers/LogController.php
+++ b/src/Controllers/LogController.php
@@ -2,7 +2,6 @@
 
 namespace Encore\Admin\Controllers;
 
-use Encore\Admin\Auth\Database\Administrator;
 use Encore\Admin\Auth\Database\OperationLog;
 use Encore\Admin\Facades\Admin;
 use Encore\Admin\Grid;
@@ -50,7 +49,7 @@ class LogController extends Controller
                 $grid->disableCreation();
 
                 $grid->filter(function ($filter) {
-                    $filter->is('user_id', 'User')->select(Administrator::all()->pluck('name', 'id'));
+                    $filter->is('user_id', 'User')->select(config('admin.database.users_model')::all()->pluck('name', 'id'));
                     $filter->is('method')->select(array_combine(OperationLog::$methods, OperationLog::$methods));
                     $filter->like('path');
                     $filter->is('ip');

--- a/src/Controllers/LogController.php
+++ b/src/Controllers/LogController.php
@@ -49,7 +49,8 @@ class LogController extends Controller
                 $grid->disableCreation();
 
                 $grid->filter(function ($filter) {
-                    $filter->is('user_id', 'User')->select(config('admin.database.users_model')::all()->pluck('name', 'id'));
+                    $model = config('admin.database.users_model');
+                    $filter->is('user_id', 'User')->select($model::all()->pluck('name', 'id'));
                     $filter->is('method')->select(array_combine(OperationLog::$methods, OperationLog::$methods));
                     $filter->like('path');
                     $filter->is('ip');

--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -32,12 +32,13 @@ class MenuController extends Controller
                 $row->column(6, function (Column $column) {
                     $form = new \Encore\Admin\Widgets\Form();
                     $form->action(admin_url('auth/menu'));
-
-                    $form->select('parent_id', trans('admin::lang.parent_id'))->options(config('admin.database.menu_model')::selectOptions());
+                    $menu_model = config('admin.database.menu_model');
+                    $role_model = config('admin.database.roles_model');
+                    $form->select('parent_id', trans('admin::lang.parent_id'))->options($menu_model::selectOptions());
                     $form->text('title', trans('admin::lang.title'))->rules('required');
                     $form->icon('icon', trans('admin::lang.icon'))->default('fa-bars')->rules('required')->help($this->iconHelp());
                     $form->text('uri', trans('admin::lang.uri'));
-                    $form->multipleSelect('roles', trans('admin::lang.roles'))->options(config('admin.database.roles_model')::all()->pluck('name', 'id'));
+                    $form->multipleSelect('roles', trans('admin::lang.roles'))->options($role_model::all()->pluck('name', 'id'));
 
                     $column->append((new Box(trans('admin::lang.new'), $form))->style('success'));
                 });
@@ -64,7 +65,9 @@ class MenuController extends Controller
      */
     protected function treeView()
     {
-        return config('admin.database.menu_model')::tree(function (Tree $tree) {
+        $model = config('admin.database.menu_model');
+
+        return $model::tree(function (Tree $tree) {
             $tree->disableCreate();
 
             $tree->branch(function ($branch) {
@@ -105,14 +108,18 @@ class MenuController extends Controller
      */
     public function form()
     {
-        return config('admin.database.menu_model')::form(function (Form $form) {
+        $model = config('admin.database.menu_model');
+
+        return $model::form(function (Form $form) {
             $form->display('id', 'ID');
 
-            $form->select('parent_id', trans('admin::lang.parent_id'))->options(config('admin.database.menu_model')::selectOptions());
+            $menu_model = config('admin.database.menu_model');
+            $role_model = config('admin.database.roles_model');
+            $form->select('parent_id', trans('admin::lang.parent_id'))->options($menu_model::selectOptions());
             $form->text('title', trans('admin::lang.title'))->rules('required');
             $form->icon('icon', trans('admin::lang.icon'))->default('fa-bars')->rules('required')->help($this->iconHelp());
             $form->text('uri', trans('admin::lang.uri'));
-            $form->multipleSelect('roles', trans('admin::lang.roles'))->options(config('admin.database.roles_model')::all()->pluck('name', 'id'));
+            $form->multipleSelect('roles', trans('admin::lang.roles'))->options($role_model::all()->pluck('name', 'id'));
 
             $form->display('created_at', trans('admin::lang.created_at'));
             $form->display('updated_at', trans('admin::lang.updated_at'));

--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -2,8 +2,6 @@
 
 namespace Encore\Admin\Controllers;
 
-use Encore\Admin\Auth\Database\Menu;
-use Encore\Admin\Auth\Database\Role;
 use Encore\Admin\Facades\Admin;
 use Encore\Admin\Form;
 use Encore\Admin\Layout\Column;
@@ -35,11 +33,11 @@ class MenuController extends Controller
                     $form = new \Encore\Admin\Widgets\Form();
                     $form->action(admin_url('auth/menu'));
 
-                    $form->select('parent_id', trans('admin::lang.parent_id'))->options(Menu::selectOptions());
+                    $form->select('parent_id', trans('admin::lang.parent_id'))->options(config('admin.database.menu_model')::selectOptions());
                     $form->text('title', trans('admin::lang.title'))->rules('required');
                     $form->icon('icon', trans('admin::lang.icon'))->default('fa-bars')->rules('required')->help($this->iconHelp());
                     $form->text('uri', trans('admin::lang.uri'));
-                    $form->multipleSelect('roles', trans('admin::lang.roles'))->options(Role::all()->pluck('name', 'id'));
+                    $form->multipleSelect('roles', trans('admin::lang.roles'))->options(config('admin.database.roles_model')::all()->pluck('name', 'id'));
 
                     $column->append((new Box(trans('admin::lang.new'), $form))->style('success'));
                 });
@@ -66,7 +64,7 @@ class MenuController extends Controller
      */
     protected function treeView()
     {
-        return Menu::tree(function (Tree $tree) {
+        return config('admin.database.menu_model')::tree(function (Tree $tree) {
             $tree->disableCreate();
 
             $tree->branch(function ($branch) {
@@ -107,14 +105,14 @@ class MenuController extends Controller
      */
     public function form()
     {
-        return Menu::form(function (Form $form) {
+        return config('admin.database.menu_model')::form(function (Form $form) {
             $form->display('id', 'ID');
 
-            $form->select('parent_id', trans('admin::lang.parent_id'))->options(Menu::selectOptions());
+            $form->select('parent_id', trans('admin::lang.parent_id'))->options(config('admin.database.menu_model')::selectOptions());
             $form->text('title', trans('admin::lang.title'))->rules('required');
             $form->icon('icon', trans('admin::lang.icon'))->default('fa-bars')->rules('required')->help($this->iconHelp());
             $form->text('uri', trans('admin::lang.uri'));
-            $form->multipleSelect('roles', trans('admin::lang.roles'))->options(Role::all()->pluck('name', 'id'));
+            $form->multipleSelect('roles', trans('admin::lang.roles'))->options(config('admin.database.roles_model')::all()->pluck('name', 'id'));
 
             $form->display('created_at', trans('admin::lang.created_at'));
             $form->display('updated_at', trans('admin::lang.updated_at'));

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -2,7 +2,6 @@
 
 namespace Encore\Admin\Controllers;
 
-use Encore\Admin\Auth\Database\Permission;
 use Encore\Admin\Facades\Admin;
 use Encore\Admin\Form;
 use Encore\Admin\Grid;
@@ -64,7 +63,7 @@ class PermissionController extends Controller
      */
     protected function grid()
     {
-        return Admin::grid(Permission::class, function (Grid $grid) {
+        return Admin::grid(config('admin.database.permissions_model'), function (Grid $grid) {
             $grid->id('ID')->sortable();
             $grid->slug(trans('admin::lang.slug'));
             $grid->name(trans('admin::lang.name'));
@@ -87,7 +86,7 @@ class PermissionController extends Controller
      */
     public function form()
     {
-        return Admin::form(Permission::class, function (Form $form) {
+        return Admin::form(config('admin.database.permissions_model'), function (Form $form) {
             $form->display('id', 'ID');
 
             $form->text('slug', trans('admin::lang.slug'))->rules('required');

--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -97,7 +97,8 @@ class RoleController extends Controller
 
             $form->text('slug', trans('admin::lang.slug'))->rules('required');
             $form->text('name', trans('admin::lang.name'))->rules('required');
-            $form->multipleSelect('permissions', trans('admin::lang.permissions'))->options(config('admin.database.permissions_model')::all()->pluck('name', 'id'));
+            $permissions_model = config('admin.database.permissions_model');
+            $form->multipleSelect('permissions', trans('admin::lang.permissions'))->options($permissions_model::all()->pluck('name', 'id'));
 
             $form->display('created_at', trans('admin::lang.created_at'));
             $form->display('updated_at', trans('admin::lang.updated_at'));

--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -2,8 +2,6 @@
 
 namespace Encore\Admin\Controllers;
 
-use Encore\Admin\Auth\Database\Permission;
-use Encore\Admin\Auth\Database\Role;
 use Encore\Admin\Facades\Admin;
 use Encore\Admin\Form;
 use Encore\Admin\Grid;
@@ -65,7 +63,7 @@ class RoleController extends Controller
      */
     protected function grid()
     {
-        return Admin::grid(Role::class, function (Grid $grid) {
+        return Admin::grid(config('admin.database.roles_model'), function (Grid $grid) {
             $grid->id('ID')->sortable();
             $grid->slug(trans('admin::lang.slug'));
             $grid->name(trans('admin::lang.name'));
@@ -94,12 +92,12 @@ class RoleController extends Controller
      */
     public function form()
     {
-        return Admin::form(Role::class, function (Form $form) {
+        return Admin::form(config('admin.database.roles_model'), function (Form $form) {
             $form->display('id', 'ID');
 
             $form->text('slug', trans('admin::lang.slug'))->rules('required');
             $form->text('name', trans('admin::lang.name'))->rules('required');
-            $form->multipleSelect('permissions', trans('admin::lang.permissions'))->options(Permission::all()->pluck('name', 'id'));
+            $form->multipleSelect('permissions', trans('admin::lang.permissions'))->options(config('admin.database.permissions_model')::all()->pluck('name', 'id'));
 
             $form->display('created_at', trans('admin::lang.created_at'));
             $form->display('updated_at', trans('admin::lang.updated_at'));

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -2,9 +2,6 @@
 
 namespace Encore\Admin\Controllers;
 
-use Encore\Admin\Auth\Database\Administrator;
-use Encore\Admin\Auth\Database\Permission;
-use Encore\Admin\Auth\Database\Role;
 use Encore\Admin\Facades\Admin;
 use Encore\Admin\Form;
 use Encore\Admin\Grid;
@@ -66,7 +63,7 @@ class UserController extends Controller
      */
     protected function grid()
     {
-        return Administrator::grid(function (Grid $grid) {
+        return config('admin.database.users_model')::grid(function (Grid $grid) {
             $grid->id('ID')->sortable();
             $grid->username(trans('admin::lang.username'));
             $grid->name(trans('admin::lang.name'));
@@ -97,7 +94,7 @@ class UserController extends Controller
      */
     public function form()
     {
-        return Administrator::form(function (Form $form) {
+        return config('admin.database.users_model')::form(function (Form $form) {
             $form->display('id', 'ID');
 
             $form->text('username', trans('admin::lang.username'))->rules('required');
@@ -111,8 +108,8 @@ class UserController extends Controller
 
             $form->ignore(['password_confirmation']);
 
-            $form->multipleSelect('roles', trans('admin::lang.roles'))->options(Role::all()->pluck('name', 'id'));
-            $form->multipleSelect('permissions', trans('admin::lang.permissions'))->options(Permission::all()->pluck('name', 'id'));
+            $form->multipleSelect('roles', trans('admin::lang.roles'))->options(config('admin.database.roles_model')::all()->pluck('name', 'id'));
+            $form->multipleSelect('permissions', trans('admin::lang.permissions'))->options(config('admin.database.permissions_model')::all()->pluck('name', 'id'));
 
             $form->display('created_at', trans('admin::lang.created_at'));
             $form->display('updated_at', trans('admin::lang.updated_at'));

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -63,7 +63,9 @@ class UserController extends Controller
      */
     protected function grid()
     {
-        return config('admin.database.users_model')::grid(function (Grid $grid) {
+        $users_model = config('admin.database.users_model');
+
+        return $users_model::grid(function (Grid $grid) {
             $grid->id('ID')->sortable();
             $grid->username(trans('admin::lang.username'));
             $grid->name(trans('admin::lang.name'));
@@ -94,7 +96,9 @@ class UserController extends Controller
      */
     public function form()
     {
-        return config('admin.database.users_model')::form(function (Form $form) {
+        $users_model = config('admin.database.users_model');
+
+        return $users_model::form(function (Form $form) {
             $form->display('id', 'ID');
 
             $form->text('username', trans('admin::lang.username'))->rules('required');
@@ -108,8 +112,10 @@ class UserController extends Controller
 
             $form->ignore(['password_confirmation']);
 
-            $form->multipleSelect('roles', trans('admin::lang.roles'))->options(config('admin.database.roles_model')::all()->pluck('name', 'id'));
-            $form->multipleSelect('permissions', trans('admin::lang.permissions'))->options(config('admin.database.permissions_model')::all()->pluck('name', 'id'));
+            $roles_model = config('admin.database.roles_model');
+            $permissions_model = config('admin.database.permissions_model');
+            $form->multipleSelect('roles', trans('admin::lang.roles'))->options($roles_model::all()->pluck('name', 'id'));
+            $form->multipleSelect('permissions', trans('admin::lang.permissions'))->options($permissions_model::all()->pluck('name', 'id'));
 
             $form->display('created_at', trans('admin::lang.created_at'));
             $form->display('updated_at', trans('admin::lang.updated_at'));

--- a/tests/FileUploadTest.php
+++ b/tests/FileUploadTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
 use Illuminate\Support\Facades\File;
 use Tests\Models\File as FileModel;
 
@@ -10,7 +9,7 @@ class FileUploadTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testFileUploadPage()

--- a/tests/FileUploadTest.php
+++ b/tests/FileUploadTest.php
@@ -8,8 +8,9 @@ class FileUploadTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        $model = config('admin.database.users_model');
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $this->be($model::first(), 'admin');
     }
 
     public function testFileUploadPage()

--- a/tests/ImageUploadTest.php
+++ b/tests/ImageUploadTest.php
@@ -9,8 +9,9 @@ class ImageUploadTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        $model = config('admin.database.users_model');
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $this->be($model::first(), 'admin');
     }
 
     public function testDisableFilter()

--- a/tests/ImageUploadTest.php
+++ b/tests/ImageUploadTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
 use Illuminate\Support\Facades\File;
 use Tests\Models\Image;
 use Tests\Models\MultipleImage;
@@ -11,7 +10,7 @@ class ImageUploadTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testDisableFilter()

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -1,14 +1,12 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
-
 class IndexTest extends TestCase
 {
     public function setUp()
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testIndex()

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -5,8 +5,9 @@ class IndexTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        $model = config('admin.database.users_model');
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $this->be($model::first(), 'admin');
     }
 
     public function testIndex()

--- a/tests/MenuTest.php
+++ b/tests/MenuTest.php
@@ -1,15 +1,12 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
-use Encore\Admin\Auth\Database\Menu;
-
 class MenuTest extends TestCase
 {
     public function setUp()
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testMenuIndex()
@@ -34,7 +31,7 @@ class MenuTest extends TestCase
             ->submitForm('Submit', $item)
             ->seePageIs('admin/auth/menu')
             ->seeInDatabase(config('admin.database.menu_table'), $item)
-            ->assertEquals(12, Menu::count());
+            ->assertEquals(12, config('admin.database.menu_model')::count());
 
         $this->expectException(\Laravel\BrowserKitTesting\HttpException::class);
 
@@ -46,7 +43,7 @@ class MenuTest extends TestCase
     public function testDeleteMenu()
     {
         $this->delete('admin/auth/menu/8')
-            ->assertEquals(7, Menu::count());
+            ->assertEquals(7, config('admin.database.menu_model')::count());
     }
 
     public function testEditMenu()
@@ -56,7 +53,7 @@ class MenuTest extends TestCase
             ->submitForm('Submit', ['title' => 'blablabla'])
             ->seePageIs('admin/auth/menu')
             ->seeInDatabase(config('admin.database.menu_table'), ['title' => 'blablabla'])
-            ->assertEquals(11, Menu::count());
+            ->assertEquals(11, config('admin.database.menu_model')::count());
     }
 
     public function testShowPage()

--- a/tests/MenuTest.php
+++ b/tests/MenuTest.php
@@ -5,8 +5,8 @@ class MenuTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $model = config('admin.database.users_model');
+        $this->be($model::first(), 'admin');
     }
 
     public function testMenuIndex()
@@ -25,13 +25,14 @@ class MenuTest extends TestCase
     {
         $item = ['parent_id' => '0', 'title' => 'Test', 'uri' => 'test'];
 
+        $menu_model = config('admin.database.menu_model');
         $this->visit('admin/auth/menu')
             ->seePageIs('admin/auth/menu')
             ->see('Menu')
             ->submitForm('Submit', $item)
             ->seePageIs('admin/auth/menu')
             ->seeInDatabase(config('admin.database.menu_table'), $item)
-            ->assertEquals(12, config('admin.database.menu_model')::count());
+            ->assertEquals(12, $menu_model::count());
 
         $this->expectException(\Laravel\BrowserKitTesting\HttpException::class);
 
@@ -42,18 +43,20 @@ class MenuTest extends TestCase
 
     public function testDeleteMenu()
     {
+        $menu_model = config('admin.database.menu_model');
         $this->delete('admin/auth/menu/8')
-            ->assertEquals(7, config('admin.database.menu_model')::count());
+            ->assertEquals(7, $menu_model::count());
     }
 
     public function testEditMenu()
     {
+        $menu_model = config('admin.database.menu_model');
         $this->visit('admin/auth/menu/1/edit')
             ->see('Menu')
             ->submitForm('Submit', ['title' => 'blablabla'])
             ->seePageIs('admin/auth/menu')
             ->seeInDatabase(config('admin.database.menu_table'), ['title' => 'blablabla'])
-            ->assertEquals(11, config('admin.database.menu_model')::count());
+            ->assertEquals(11, $menu_model::count());
     }
 
     public function testShowPage()

--- a/tests/OperationLogTest.php
+++ b/tests/OperationLogTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
 use Encore\Admin\Auth\Database\OperationLog;
 
 class OperationLogTest extends TestCase
@@ -9,7 +8,7 @@ class OperationLogTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testOperationLogIndex()

--- a/tests/OperationLogTest.php
+++ b/tests/OperationLogTest.php
@@ -8,7 +8,8 @@ class OperationLogTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $user_model = config('admin.database.users_model');
+        $this->be($user_model::first(), 'admin');
     }
 
     public function testOperationLogIndex()

--- a/tests/PermissionsTest.php
+++ b/tests/PermissionsTest.php
@@ -6,12 +6,14 @@ class PermissionsTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $users_model = config('admin.database.users_model');
+        $this->be($users_model::first(), 'admin');
     }
 
     public function testPermissionsIndex()
     {
-        $this->assertTrue(config('admin.database.users_model')::first()->isAdministrator());
+        $users_model = config('admin.database.users_model');
+        $this->assertTrue($users_model::first()->isAdministrator());
 
         $this->visit('admin/auth/permissions')
             ->see('Permissions');
@@ -19,6 +21,9 @@ class PermissionsTest extends TestCase
 
     public function testAddAndDeletePermissions()
     {
+        $users_model = config('admin.database.users_model');
+        $permissions_model = config('admin.database.permissions_model');
+
         $this->visit('admin/auth/permissions/create')
             ->see('Permissions')
             ->submitForm('Submit', ['slug' => 'can-edit', 'name' => 'Can edit'])
@@ -29,16 +34,16 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/permissions')
             ->seeInDatabase(config('admin.database.permissions_table'), ['slug' => 'can-edit', 'name' => 'Can edit'])
             ->seeInDatabase(config('admin.database.permissions_table'), ['slug' => 'can-delete', 'name' => 'Can delete'])
-            ->assertEquals(2, config('admin.database.permissions_model')::count());
+            ->assertEquals(2, $permissions_model::count());
 
-        $this->assertTrue(config('admin.database.users_model')::first()->can('can-edit'));
-        $this->assertTrue(config('admin.database.users_model')::first()->can('can-delete'));
+        $this->assertTrue($users_model::first()->can('can-edit'));
+        $this->assertTrue($users_model::first()->can('can-delete'));
 
         $this->delete('admin/auth/permissions/1')
-            ->assertEquals(1, config('admin.database.permissions_model')::count());
+            ->assertEquals(1, $permissions_model::count());
 
         $this->delete('admin/auth/permissions/2')
-            ->assertEquals(0, config('admin.database.permissions_model')::count());
+            ->assertEquals(0, $permissions_model::count());
     }
 
     public function testAddPermissionToRole()
@@ -48,7 +53,8 @@ class PermissionsTest extends TestCase
             ->submitForm('Submit', ['slug' => 'can-create', 'name' => 'Can Create'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(1, config('admin.database.permissions_model')::count());
+        $permissions_model = config('admin.database.permissions_model');
+        $this->assertEquals(1, $permissions_model::count());
 
         $this->visit('admin/auth/roles/1/edit')
             ->see('Edit')
@@ -64,7 +70,8 @@ class PermissionsTest extends TestCase
             ->submitForm('Submit', ['slug' => 'can-create', 'name' => 'Can Create'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(1, config('admin.database.permissions_model')::count());
+        $permissions_model = config('admin.database.permissions_model');
+        $this->assertEquals(1, $permissions_model::count());
 
         $this->visit('admin/auth/users/1/edit')
             ->see('Edit')
@@ -89,21 +96,23 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.users_table'), ['username' => 'Test']);
 
-        $this->assertFalse(config('admin.database.users_model')::find(2)->isAdministrator());
+        $users_model = config('admin.database.users_model');
+        $permissions_model = config('admin.database.permissions_model');
+        $this->assertFalse($users_model::find(2)->isAdministrator());
 
         $this->visit('admin/auth/permissions/create')
             ->see('Permissions')
             ->submitForm('Submit', ['slug' => 'can-update', 'name' => 'Can Update'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(1, config('admin.database.permissions_model')::count());
+        $this->assertEquals(1, $permissions_model::count());
 
         $this->visit('admin/auth/permissions/create')
             ->see('Permissions')
             ->submitForm('Submit', ['slug' => 'can-remove', 'name' => 'Can Remove'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(2, config('admin.database.permissions_model')::count());
+        $this->assertEquals(2, $permissions_model::count());
 
         $this->visit('admin/auth/users/2/edit')
             ->see('Edit')
@@ -111,8 +120,8 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.user_permissions_table'), ['user_id' => 2, 'permission_id' => 1]);
 
-        $this->assertTrue(config('admin.database.users_model')::find(2)->can('can-update'));
-        $this->assertTrue(config('admin.database.users_model')::find(2)->cannot('can-remove'));
+        $this->assertTrue($users_model::find(2)->can('can-update'));
+        $this->assertTrue($users_model::find(2)->cannot('can-remove'));
 
         $this->visit('admin/auth/users/2/edit')
             ->see('Edit')
@@ -120,7 +129,7 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.user_permissions_table'), ['user_id' => 2, 'permission_id' => 2]);
 
-        $this->assertTrue(config('admin.database.users_model')::find(2)->can('can-remove'));
+        $this->assertTrue($users_model::find(2)->can('can-remove'));
 
         $this->visit('admin/auth/users/2/edit')
             ->see('Edit')
@@ -129,8 +138,8 @@ class PermissionsTest extends TestCase
             ->missingFromDatabase(config('admin.database.user_permissions_table'), ['user_id' => 2, 'permission_id' => 1])
             ->missingFromDatabase(config('admin.database.user_permissions_table'), ['user_id' => 2, 'permission_id' => 2]);
 
-        $this->assertTrue(config('admin.database.users_model')::find(2)->cannot('can-update'));
-        $this->assertTrue(config('admin.database.users_model')::find(2)->cannot('can-remove'));
+        $this->assertTrue($users_model::find(2)->cannot('can-update'));
+        $this->assertTrue($users_model::find(2)->cannot('can-remove'));
     }
 
     public function testPermissionThroughRole()
@@ -149,7 +158,11 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.users_table'), ['username' => 'Test']);
 
-        $this->assertFalse(config('admin.database.users_model')::find(2)->isAdministrator());
+        $users_model = config('admin.database.users_model');
+        $roles_model = config('admin.database.roles_model');
+        $permissions_model = config('admin.database.permissions_model');
+
+        $this->assertFalse($users_model::find(2)->isAdministrator());
 
         // 2.add a role
         $this->visit('admin/auth/roles/create')
@@ -157,9 +170,9 @@ class PermissionsTest extends TestCase
             ->submitForm('Submit', ['slug' => 'developer', 'name' => 'Developer...'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['slug' => 'developer', 'name' => 'Developer...'])
-            ->assertEquals(2, config('admin.database.roles_model')::count());
+            ->assertEquals(2, $roles_model::count());
 
-        $this->assertFalse(config('admin.database.users_model')::find(2)->isRole('developer'));
+        $this->assertFalse($users_model::find(2)->isRole('developer'));
 
         // 3.assign role to user
         $this->visit('admin/auth/users/2/edit')
@@ -168,7 +181,7 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.role_users_table'), ['user_id' => 2, 'role_id' => 2]);
 
-        $this->assertTrue(config('admin.database.users_model')::find(2)->isRole('developer'));
+        $this->assertTrue($users_model::find(2)->isRole('developer'));
 
         //  4.add a permission
         $this->visit('admin/auth/permissions/create')
@@ -176,9 +189,9 @@ class PermissionsTest extends TestCase
             ->submitForm('Submit', ['slug' => 'can-remove', 'name' => 'Can Remove'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(1, config('admin.database.permissions_model')::count());
+        $this->assertEquals(1, $permissions_model::count());
 
-        $this->assertTrue(config('admin.database.users_model')::find(2)->cannot('can-remove'));
+        $this->assertTrue($users_model::find(2)->cannot('can-remove'));
 
         // 5.assign permission to role
         $this->visit('admin/auth/roles/2/edit')
@@ -187,24 +200,26 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.role_permissions_table'), ['role_id' => 2, 'permission_id' => 1]);
 
-        $this->assertTrue(config('admin.database.users_model')::find(2)->can('can-remove'));
+        $this->assertTrue($users_model::find(2)->can('can-remove'));
     }
 
     public function testEditPermission()
     {
+        $permissions_model = config('admin.database.permissions_model');
+
         $this->visit('admin/auth/permissions/create')
             ->see('Permissions')
             ->submitForm('Submit', ['slug' => 'can-edit', 'name' => 'Can edit'])
             ->seePageIs('admin/auth/permissions')
             ->seeInDatabase(config('admin.database.permissions_table'), ['slug' => 'can-edit'])
             ->seeInDatabase(config('admin.database.permissions_table'), ['name' => 'Can edit'])
-            ->assertEquals(1, config('admin.database.permissions_model')::count());
+            ->assertEquals(1, $permissions_model::count());
 
         $this->visit('admin/auth/permissions/1/edit')
             ->see('Permissions')
             ->submitForm('Submit', ['slug' => 'can-delete'])
             ->seePageIs('admin/auth/permissions')
             ->seeInDatabase(config('admin.database.permissions_table'), ['slug' => 'can-delete'])
-            ->assertEquals(1, config('admin.database.permissions_model')::count());
+            ->assertEquals(1, $permissions_model::count());
     }
 }

--- a/tests/PermissionsTest.php
+++ b/tests/PermissionsTest.php
@@ -1,21 +1,17 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
-use Encore\Admin\Auth\Database\Permission;
-use Encore\Admin\Auth\Database\Role;
-
 class PermissionsTest extends TestCase
 {
     public function setUp()
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testPermissionsIndex()
     {
-        $this->assertTrue(Administrator::first()->isAdministrator());
+        $this->assertTrue(config('admin.database.users_model')::first()->isAdministrator());
 
         $this->visit('admin/auth/permissions')
             ->see('Permissions');
@@ -33,16 +29,16 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/permissions')
             ->seeInDatabase(config('admin.database.permissions_table'), ['slug' => 'can-edit', 'name' => 'Can edit'])
             ->seeInDatabase(config('admin.database.permissions_table'), ['slug' => 'can-delete', 'name' => 'Can delete'])
-            ->assertEquals(2, Permission::count());
+            ->assertEquals(2, config('admin.database.permissions_model')::count());
 
-        $this->assertTrue(Administrator::first()->can('can-edit'));
-        $this->assertTrue(Administrator::first()->can('can-delete'));
+        $this->assertTrue(config('admin.database.users_model')::first()->can('can-edit'));
+        $this->assertTrue(config('admin.database.users_model')::first()->can('can-delete'));
 
         $this->delete('admin/auth/permissions/1')
-            ->assertEquals(1, Permission::count());
+            ->assertEquals(1, config('admin.database.permissions_model')::count());
 
         $this->delete('admin/auth/permissions/2')
-            ->assertEquals(0, Permission::count());
+            ->assertEquals(0, config('admin.database.permissions_model')::count());
     }
 
     public function testAddPermissionToRole()
@@ -52,7 +48,7 @@ class PermissionsTest extends TestCase
             ->submitForm('Submit', ['slug' => 'can-create', 'name' => 'Can Create'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(1, Permission::count());
+        $this->assertEquals(1, config('admin.database.permissions_model')::count());
 
         $this->visit('admin/auth/roles/1/edit')
             ->see('Edit')
@@ -68,7 +64,7 @@ class PermissionsTest extends TestCase
             ->submitForm('Submit', ['slug' => 'can-create', 'name' => 'Can Create'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(1, Permission::count());
+        $this->assertEquals(1, config('admin.database.permissions_model')::count());
 
         $this->visit('admin/auth/users/1/edit')
             ->see('Edit')
@@ -93,21 +89,21 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.users_table'), ['username' => 'Test']);
 
-        $this->assertFalse(Administrator::find(2)->isAdministrator());
+        $this->assertFalse(config('admin.database.users_model')::find(2)->isAdministrator());
 
         $this->visit('admin/auth/permissions/create')
             ->see('Permissions')
             ->submitForm('Submit', ['slug' => 'can-update', 'name' => 'Can Update'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(1, Permission::count());
+        $this->assertEquals(1, config('admin.database.permissions_model')::count());
 
         $this->visit('admin/auth/permissions/create')
             ->see('Permissions')
             ->submitForm('Submit', ['slug' => 'can-remove', 'name' => 'Can Remove'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(2, Permission::count());
+        $this->assertEquals(2, config('admin.database.permissions_model')::count());
 
         $this->visit('admin/auth/users/2/edit')
             ->see('Edit')
@@ -115,8 +111,8 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.user_permissions_table'), ['user_id' => 2, 'permission_id' => 1]);
 
-        $this->assertTrue(Administrator::find(2)->can('can-update'));
-        $this->assertTrue(Administrator::find(2)->cannot('can-remove'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->can('can-update'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->cannot('can-remove'));
 
         $this->visit('admin/auth/users/2/edit')
             ->see('Edit')
@@ -124,7 +120,7 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.user_permissions_table'), ['user_id' => 2, 'permission_id' => 2]);
 
-        $this->assertTrue(Administrator::find(2)->can('can-remove'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->can('can-remove'));
 
         $this->visit('admin/auth/users/2/edit')
             ->see('Edit')
@@ -133,8 +129,8 @@ class PermissionsTest extends TestCase
             ->missingFromDatabase(config('admin.database.user_permissions_table'), ['user_id' => 2, 'permission_id' => 1])
             ->missingFromDatabase(config('admin.database.user_permissions_table'), ['user_id' => 2, 'permission_id' => 2]);
 
-        $this->assertTrue(Administrator::find(2)->cannot('can-update'));
-        $this->assertTrue(Administrator::find(2)->cannot('can-remove'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->cannot('can-update'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->cannot('can-remove'));
     }
 
     public function testPermissionThroughRole()
@@ -153,7 +149,7 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.users_table'), ['username' => 'Test']);
 
-        $this->assertFalse(Administrator::find(2)->isAdministrator());
+        $this->assertFalse(config('admin.database.users_model')::find(2)->isAdministrator());
 
         // 2.add a role
         $this->visit('admin/auth/roles/create')
@@ -161,9 +157,9 @@ class PermissionsTest extends TestCase
             ->submitForm('Submit', ['slug' => 'developer', 'name' => 'Developer...'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['slug' => 'developer', 'name' => 'Developer...'])
-            ->assertEquals(2, Role::count());
+            ->assertEquals(2, config('admin.database.roles_model')::count());
 
-        $this->assertFalse(Administrator::find(2)->isRole('developer'));
+        $this->assertFalse(config('admin.database.users_model')::find(2)->isRole('developer'));
 
         // 3.assign role to user
         $this->visit('admin/auth/users/2/edit')
@@ -172,7 +168,7 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.role_users_table'), ['user_id' => 2, 'role_id' => 2]);
 
-        $this->assertTrue(Administrator::find(2)->isRole('developer'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->isRole('developer'));
 
         //  4.add a permission
         $this->visit('admin/auth/permissions/create')
@@ -180,9 +176,9 @@ class PermissionsTest extends TestCase
             ->submitForm('Submit', ['slug' => 'can-remove', 'name' => 'Can Remove'])
             ->seePageIs('admin/auth/permissions');
 
-        $this->assertEquals(1, Permission::count());
+        $this->assertEquals(1, config('admin.database.permissions_model')::count());
 
-        $this->assertTrue(Administrator::find(2)->cannot('can-remove'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->cannot('can-remove'));
 
         // 5.assign permission to role
         $this->visit('admin/auth/roles/2/edit')
@@ -191,7 +187,7 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.role_permissions_table'), ['role_id' => 2, 'permission_id' => 1]);
 
-        $this->assertTrue(Administrator::find(2)->can('can-remove'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->can('can-remove'));
     }
 
     public function testEditPermission()
@@ -202,13 +198,13 @@ class PermissionsTest extends TestCase
             ->seePageIs('admin/auth/permissions')
             ->seeInDatabase(config('admin.database.permissions_table'), ['slug' => 'can-edit'])
             ->seeInDatabase(config('admin.database.permissions_table'), ['name' => 'Can edit'])
-            ->assertEquals(1, Permission::count());
+            ->assertEquals(1, config('admin.database.permissions_model')::count());
 
         $this->visit('admin/auth/permissions/1/edit')
             ->see('Permissions')
             ->submitForm('Submit', ['slug' => 'can-delete'])
             ->seePageIs('admin/auth/permissions')
             ->seeInDatabase(config('admin.database.permissions_table'), ['slug' => 'can-delete'])
-            ->assertEquals(1, Permission::count());
+            ->assertEquals(1, config('admin.database.permissions_model')::count());
     }
 }

--- a/tests/RolesTest.php
+++ b/tests/RolesTest.php
@@ -6,7 +6,8 @@ class RolesTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $users_model = config('admin.database.users_model');
+        $this->be($users_model::first(), 'admin');
     }
 
     public function testRolesIndex()
@@ -18,12 +19,13 @@ class RolesTest extends TestCase
 
     public function testAddRole()
     {
+        $roles_model = config('admin.database.roles_model');
         $this->visit('admin/auth/roles/create')
             ->see('Roles')
             ->submitForm('Submit', ['slug' => 'developer', 'name' => 'Developer...'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['slug' => 'developer', 'name' => 'Developer...'])
-            ->assertEquals(2, config('admin.database.roles_model')::count());
+            ->assertEquals(2, $roles_model::count());
     }
 
     public function testAddRoleToUser()
@@ -42,16 +44,19 @@ class RolesTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.users_table'), ['username' => 'Test']);
 
-        $this->assertEquals(1, config('admin.database.roles_model')::count());
+        $users_model = config('admin.database.users_model');
+        $roles_model = config('admin.database.roles_model');
+
+        $this->assertEquals(1, $roles_model::count());
 
         $this->visit('admin/auth/roles/create')
             ->see('Roles')
             ->submitForm('Submit', ['slug' => 'developer', 'name' => 'Developer...'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['slug' => 'developer', 'name' => 'Developer...'])
-            ->assertEquals(2, config('admin.database.roles_model')::count());
+            ->assertEquals(2, $roles_model::count());
 
-        $this->assertFalse(config('admin.database.users_model')::find(2)->isRole('developer'));
+        $this->assertFalse($users_model::find(2)->isRole('developer'));
 
         $this->visit('admin/auth/users/2/edit')
             ->see('Edit')
@@ -59,37 +64,41 @@ class RolesTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.role_users_table'), ['user_id' => 2, 'role_id' => 2]);
 
-        $this->assertTrue(config('admin.database.users_model')::find(2)->isRole('developer'));
+        $this->assertTrue($users_model::find(2)->isRole('developer'));
 
-        $this->assertFalse(config('admin.database.users_model')::find(2)->inRoles(['editor', 'operator']));
-        $this->assertTrue(config('admin.database.users_model')::find(2)->inRoles(['developer', 'operator', 'editor']));
+        $this->assertFalse($users_model::find(2)->inRoles(['editor', 'operator']));
+        $this->assertTrue($users_model::find(2)->inRoles(['developer', 'operator', 'editor']));
     }
 
     public function testDeleteRole()
     {
-        $this->assertEquals(1, config('admin.database.roles_model')::count());
+        $roles_model = config('admin.database.roles_model');
+
+        $this->assertEquals(1, $roles_model::count());
 
         $this->visit('admin/auth/roles/create')
             ->see('Roles')
             ->submitForm('Submit', ['slug' => 'developer', 'name' => 'Developer...'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['slug' => 'developer', 'name' => 'Developer...'])
-            ->assertEquals(2, config('admin.database.roles_model')::count());
+            ->assertEquals(2, $roles_model::count());
 
         $this->delete('admin/auth/roles/2')
-            ->assertEquals(1, config('admin.database.roles_model')::count());
+            ->assertEquals(1, $roles_model::count());
 
         $this->delete('admin/auth/roles/1')
-            ->assertEquals(0, config('admin.database.roles_model')::count());
+            ->assertEquals(0, $roles_model::count());
     }
 
     public function testEditRole()
     {
+        $roles_model = config('admin.database.roles_model');
+
         $this->visit('admin/auth/roles/1/edit')
             ->see('Roles')
             ->submitForm('Submit', ['name' => 'blablabla'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['name' => 'blablabla'])
-            ->assertEquals(1, config('admin.database.roles_model')::count());
+            ->assertEquals(1, $roles_model::count());
     }
 }

--- a/tests/RolesTest.php
+++ b/tests/RolesTest.php
@@ -1,15 +1,12 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
-use Encore\Admin\Auth\Database\Role;
-
 class RolesTest extends TestCase
 {
     public function setUp()
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testRolesIndex()
@@ -26,7 +23,7 @@ class RolesTest extends TestCase
             ->submitForm('Submit', ['slug' => 'developer', 'name' => 'Developer...'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['slug' => 'developer', 'name' => 'Developer...'])
-            ->assertEquals(2, Role::count());
+            ->assertEquals(2, config('admin.database.roles_model')::count());
     }
 
     public function testAddRoleToUser()
@@ -45,16 +42,16 @@ class RolesTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.users_table'), ['username' => 'Test']);
 
-        $this->assertEquals(1, Role::count());
+        $this->assertEquals(1, config('admin.database.roles_model')::count());
 
         $this->visit('admin/auth/roles/create')
             ->see('Roles')
             ->submitForm('Submit', ['slug' => 'developer', 'name' => 'Developer...'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['slug' => 'developer', 'name' => 'Developer...'])
-            ->assertEquals(2, Role::count());
+            ->assertEquals(2, config('admin.database.roles_model')::count());
 
-        $this->assertFalse(Administrator::find(2)->isRole('developer'));
+        $this->assertFalse(config('admin.database.users_model')::find(2)->isRole('developer'));
 
         $this->visit('admin/auth/users/2/edit')
             ->see('Edit')
@@ -62,28 +59,28 @@ class RolesTest extends TestCase
             ->seePageIs('admin/auth/users')
             ->seeInDatabase(config('admin.database.role_users_table'), ['user_id' => 2, 'role_id' => 2]);
 
-        $this->assertTrue(Administrator::find(2)->isRole('developer'));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->isRole('developer'));
 
-        $this->assertFalse(Administrator::find(2)->inRoles(['editor', 'operator']));
-        $this->assertTrue(Administrator::find(2)->inRoles(['developer', 'operator', 'editor']));
+        $this->assertFalse(config('admin.database.users_model')::find(2)->inRoles(['editor', 'operator']));
+        $this->assertTrue(config('admin.database.users_model')::find(2)->inRoles(['developer', 'operator', 'editor']));
     }
 
     public function testDeleteRole()
     {
-        $this->assertEquals(1, Role::count());
+        $this->assertEquals(1, config('admin.database.roles_model')::count());
 
         $this->visit('admin/auth/roles/create')
             ->see('Roles')
             ->submitForm('Submit', ['slug' => 'developer', 'name' => 'Developer...'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['slug' => 'developer', 'name' => 'Developer...'])
-            ->assertEquals(2, Role::count());
+            ->assertEquals(2, config('admin.database.roles_model')::count());
 
         $this->delete('admin/auth/roles/2')
-            ->assertEquals(1, Role::count());
+            ->assertEquals(1, config('admin.database.roles_model')::count());
 
         $this->delete('admin/auth/roles/1')
-            ->assertEquals(0, Role::count());
+            ->assertEquals(0, config('admin.database.roles_model')::count());
     }
 
     public function testEditRole()
@@ -93,6 +90,6 @@ class RolesTest extends TestCase
             ->submitForm('Submit', ['name' => 'blablabla'])
             ->seePageIs('admin/auth/roles')
             ->seeInDatabase(config('admin.database.roles_table'), ['name' => 'blablabla'])
-            ->assertEquals(1, Role::count());
+            ->assertEquals(1, config('admin.database.roles_model')::count());
     }
 }

--- a/tests/UserFormTest.php
+++ b/tests/UserFormTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
 use Tests\Models\User as UserModel;
 
 class UserFormTest extends TestCase
@@ -9,7 +8,7 @@ class UserFormTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testCreatePage()

--- a/tests/UserFormTest.php
+++ b/tests/UserFormTest.php
@@ -8,7 +8,8 @@ class UserFormTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $users_model = config('admin.database.users_model');
+        $this->be($users_model::first(), 'admin');
     }
 
     public function testCreatePage()

--- a/tests/UserGridTest.php
+++ b/tests/UserGridTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
 use Tests\Models\Profile as ProfileModel;
 use Tests\Models\User as UserModel;
 
@@ -10,7 +9,7 @@ class UserGridTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testIndexPage()

--- a/tests/UserGridTest.php
+++ b/tests/UserGridTest.php
@@ -9,7 +9,8 @@ class UserGridTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $users_model = config('admin.database.users_model');
+        $this->be($users_model::first(), 'admin');
     }
 
     public function testIndexPage()

--- a/tests/UserSettingTest.php
+++ b/tests/UserSettingTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
 use Illuminate\Support\Facades\File;
 
 class UserSettingTest extends TestCase
@@ -9,7 +8,7 @@ class UserSettingTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(Administrator::first(), 'admin');
+        $this->be(config('admin.database.users_model')::first(), 'admin');
     }
 
     public function testVisitSettingPage()
@@ -48,7 +47,7 @@ class UserSettingTest extends TestCase
             ->press('Submit')
             ->seePageIs('admin/auth/setting');
 
-        $avatar = Administrator::first()->avatar;
+        $avatar = config('admin.database.users_model')::first()->avatar;
 
         $this->assertEquals('http://localhost:8000/upload/image/test.jpg', $avatar);
     }
@@ -77,7 +76,7 @@ class UserSettingTest extends TestCase
             ->submitForm('Submit', $data)
             ->seePageIs('admin/auth/setting');
 
-        $this->assertTrue(app('hash')->check($data['password'], Administrator::first()->makeVisible('password')->password));
+        $this->assertTrue(app('hash')->check($data['password'], config('admin.database.users_model')::first()->makeVisible('password')->password));
 
         $this->visit('admin/auth/logout')
             ->seePageIs('admin/auth/login')

--- a/tests/UserSettingTest.php
+++ b/tests/UserSettingTest.php
@@ -8,7 +8,8 @@ class UserSettingTest extends TestCase
     {
         parent::setUp();
 
-        $this->be(config('admin.database.users_model')::first(), 'admin');
+        $users_model = config('admin.database.users_model');
+        $this->be($users_model::first(), 'admin');
     }
 
     public function testVisitSettingPage()
@@ -47,7 +48,8 @@ class UserSettingTest extends TestCase
             ->press('Submit')
             ->seePageIs('admin/auth/setting');
 
-        $avatar = config('admin.database.users_model')::first()->avatar;
+        $users_model = config('admin.database.users_model');
+        $avatar = $users_model::first()->avatar;
 
         $this->assertEquals('http://localhost:8000/upload/image/test.jpg', $avatar);
     }
@@ -76,7 +78,8 @@ class UserSettingTest extends TestCase
             ->submitForm('Submit', $data)
             ->seePageIs('admin/auth/setting');
 
-        $this->assertTrue(app('hash')->check($data['password'], config('admin.database.users_model')::first()->makeVisible('password')->password));
+        $users_model = config('admin.database.users_model');
+        $this->assertTrue(app('hash')->check($data['password'], $users_model::first()->makeVisible('password')->password));
 
         $this->visit('admin/auth/logout')
             ->seePageIs('admin/auth/login')

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
-
 class UsersTest extends TestCase
 {
     protected $user;
@@ -10,7 +8,7 @@ class UsersTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = Administrator::first();
+        $this->user = config('admin.database.users_model')::first();
 
         $this->be($this->user, 'admin');
     }

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -8,7 +8,8 @@ class UsersTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = config('admin.database.users_model')::first();
+        $users_model = config('admin.database.users_model');
+        $this->user = $users_model::first();
 
         $this->be($this->user, 'admin');
     }


### PR DESCRIPTION
- 现在admin.php中的model自定义值底层代码没有引用，而是采用自带的model，这样自定义的意义没有了。

- 我的提交时现将底层相关地址全部修改，这样admin.php中的自定义model可以由使用者任意配置。

- 我在phpunit测试的时候，有两处不通过，但是在我修改前测试时也是不通过的，不知道是不是我本地的问题，两处如下：

```php
UserFormTest::testSubmitForm
UserGridTest::testGridPagination
```
