### PR TITLE
修复表单中一对多字段jquery选择器混乱问题，方法为在原有class选择器之外，加上name选择。以此来避免重复

### DIFF
--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -163,10 +163,11 @@ class File extends Field
         $this->options(['overwriteInitial' => true]);
 
         $options = json_encode($this->options);
+	$elementName =  $this->elementName ?: $this->formatName($this->column);
 
         $this->script = <<<EOT
 
-$("input{$this->getElementClassSelector()}").fileinput({$options});
+$("input{$this->getElementClassSelector()}[name='{$elementName}']").fileinput({$options});
 
 EOT;
 

--- a/src/Form/Field/SwitchField.php
+++ b/src/Form/Field/SwitchField.php
@@ -39,23 +39,24 @@ class SwitchField extends Field
 
     public function render()
     {
-        foreach ($this->states as $state => $option) {
+	 foreach ($this->states as $state => $option) {
             if ($this->value() == $option['value']) {
                 $this->value = $state;
                 break;
             }
         }
 
+        $elementName =  $this->elementName ?: $this->formatName($this->column);
         $this->script = <<<EOT
 
-$('{$this->getElementClassSelector()}.la_checkbox').bootstrapSwitch({
+$("{$this->getElementClassSelector()}[data-name='{$elementName}'].la_checkbox").bootstrapSwitch({
     size:'small',
     onText: '{$this->states['on']['text']}',
     offText: '{$this->states['off']['text']}',
     onColor: '{$this->states['on']['color']}',
     offColor: '{$this->states['off']['color']}',
     onSwitchChange: function(event, state) {
-        $('{$this->getElementClassSelector()}').val(state ? 'on' : 'off');
+        $("{$this->getElementClassSelector()}[name='{$elementName}']").val(state ? 'on' : 'off');
     }
 });
 

--- a/views/form/switchfield.blade.php
+++ b/views/form/switchfield.blade.php
@@ -6,8 +6,8 @@
 
         @include('admin::form.error')
 
-        <input type="checkbox" class="{{$class}} la_checkbox" {{ old($column, $value) == 'on' ? 'checked' : '' }} {!! $attributes !!} />
-        <input type="hidden" class="{{$class}}" name="{{$name}}" class="" value="{{ old($column, $value) }}" />
+        <input type="checkbox" class="{{$class}} la_checkbox"  data-name="{{$name}}"  {{ old($column, $value) == 'on' ? 'checked' : '' }} {!! $attributes !!} />
+        <input type="hidden" class="{{$class}}" name="{{$name}}"  value="{{ old($column, $value) }}" />
 
         @include('admin::form.help-block')
 


### PR DESCRIPTION
#719 #
具体问题请见我提出的issue
目前仅对 file.php 和 switchField.php 做了修改。
希望采纳