### PR TITLE
support old values in nested forms

### DIFF
--- a/src/Form/Field/Text.php
+++ b/src/Form/Field/Text.php
@@ -17,11 +17,12 @@ class Text extends Field
     {
         $this->initPlainInput();
 
+        $elementName = $this->elementName ?: $this->formatName($this->column);
         $this->prepend('<i class="fa fa-pencil"></i>')
             ->defaultAttribute('type', 'text')
             ->defaultAttribute('id', $this->id)
-            ->defaultAttribute('name', $this->elementName ?: $this->formatName($this->column))
-            ->defaultAttribute('value', old($this->column, $this->value()))
+            ->defaultAttribute('name', $elementName)
+            ->defaultAttribute('value', old($elementName, $this->value()))
             ->defaultAttribute('class', 'form-control '.$this->getElementClassString())
             ->defaultAttribute('placeholder', $this->getPlaceholder());
 


### PR DESCRIPTION
assuming thisform:
```php
$form->text('name')->rules('min:100|string');
$form->hasMany('values', function (Form\NestedForm $form) {
    $form->text('name');
} );
```

if you submit the form and don't fill in enough chars for the main 'name', the old value  in the nested form uses the main 'name' property.

This fixes the problem
