### PR TITLE
Add ability to add custom tools for ModelTree.

### DIFF
--- a/src/Tree.php
+++ b/src/Tree.php
@@ -3,9 +3,7 @@
 namespace Encore\Admin;
 
 use Closure;
-
 use Encore\Admin\Tree\Tools;
-
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Database\Eloquent\Model;
 

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -2,6 +2,10 @@
 
 namespace Encore\Admin;
 
+use Closure;
+
+use Encore\Admin\Tree\Tools;
+
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Database\Eloquent\Model;
 
@@ -58,6 +62,13 @@ class Tree implements Renderable
     protected $nestableOptions = [];
 
     /**
+     * Header tools.
+     *
+     * @var Tools
+     */
+    public $tools;
+
+    /**
      * Menu constructor.
      *
      * @param Model|null $model
@@ -69,11 +80,21 @@ class Tree implements Renderable
         $this->path = app('request')->getPathInfo();
         $this->elementId .= uniqid();
 
+        $this->setupTools();
+
         if ($callback instanceof \Closure) {
             call_user_func($callback, $this);
         }
 
         $this->initBranchCallback();
+    }
+
+    /**
+     * Setup tree tools.
+     */
+    public function setupTools()
+    {
+        $this->tools = new Tools($this);
     }
 
     /**
@@ -243,9 +264,22 @@ SCRIPT;
     {
         return [
             'id'        => $this->elementId,
+            'tools'     => $this->tools->render(),
             'items'     => $this->model->withQuery($this->queryCallback)->toTree(),
             'useCreate' => $this->useCreate,
         ];
+    }
+
+    /**
+     * Setup grid tools.
+     *
+     * @param Closure $callback
+     *
+     * @return void
+     */
+    public function tools(Closure $callback)
+    {
+        call_user_func($callback, $this->tools);
     }
 
     /**

--- a/src/Tree/Tools.php
+++ b/src/Tree/Tools.php
@@ -2,12 +2,10 @@
 
 namespace Encore\Admin\Tree;
 
-use Encore\Admin\Facades\Admin;
 use Encore\Admin\Tree;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 class Tools implements Renderable
 {

--- a/src/Tree/Tools.php
+++ b/src/Tree/Tools.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Collection;
 
 class Tools implements Renderable
 {
-
     /**
      * Parent tree.
      *

--- a/src/Tree/Tools.php
+++ b/src/Tree/Tools.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Encore\Admin\Tree;
+
+use Encore\Admin\Facades\Admin;
+use Encore\Admin\Tree;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class Tools implements Renderable
+{
+
+    /**
+     * Parent tree.
+     *
+     * @var Tree
+     */
+    protected $tree;
+
+    /**
+     * Collection of tools.
+     *
+     * @var Collection
+     */
+    protected $tools;
+
+    /**
+     * Create a new Tools instance.
+     *
+     * @param Builder $builder
+     */
+    public function __construct(Tree $tree)
+    {
+        $this->tree = $tree;
+        $this->tools = new Collection();
+    }
+
+    /**
+     * Prepend a tool.
+     *
+     * @param string $tool
+     *
+     * @return $this
+     */
+    public function add($tool)
+    {
+        $this->tools->push($tool);
+
+        return $this;
+    }
+
+    /**
+     * Render header tools bar.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        return $this->tools->map(function ($tool) {
+            if ($tool instanceof Renderable) {
+                return $tool->render();
+            }
+
+            if ($tool instanceof Htmlable) {
+                return $tool->toHtml();
+            }
+
+            return (string) $tool;
+        })->implode(' ');
+    }
+}

--- a/views/tree.blade.php
+++ b/views/tree.blade.php
@@ -19,6 +19,10 @@
             <a class="btn btn-warning btn-sm {{ $id }}-refresh"><i class="fa fa-refresh"></i>&nbsp;{{ trans('admin::lang.refresh') }}</a>
         </div>
 
+        <div class="btn-group">
+            {!! $tools !!}
+        </div>
+
         @if($useCreate)
         <div class="btn-group pull-right">
             <a class="btn btn-success btn-sm" href="{{ $path }}/create"><i class="fa fa-save"></i>&nbsp;{{ trans('admin::lang.new') }}</a>


### PR DESCRIPTION
ModelTree doesn't have ability to add custom tools like ModelForm & ModelGrid at this moment. This pull request adds this ability. You can then add a custom button using codes like the following.
````
    public function index()
    {
        return Admin::content(function (Content $content) {

            $content->header('Categories');

            $content->body(Category::tree(function($tree) {
                $tree->tools(function($tools) {
                    $tools->add('<a class="btn btn-sm btn-danger"><i class="fa fa-trash"></i>&nbsp;&nbsp;Export JSON</a>');
                });
            }));
        });
    }

````
