### PR TITLE
Add getItems() to access the tree’s items.

### DIFF
--- a/src/Tree.php
+++ b/src/Tree.php
@@ -235,11 +235,12 @@ SCRIPT;
     }
 
     /**
-     * Return all items of the tree
+     * Return all items of the tree.
      *
      * @param array $items
      */
-    public function getItems() {
+    public function getItems()
+    {
         return $this->model->withQuery($this->queryCallback)->toTree();
     }
 

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -235,6 +235,15 @@ SCRIPT;
     }
 
     /**
+     * Return all items of the tree
+     *
+     * @param array $items
+     */
+    public function getItems() {
+        return $this->model->withQuery($this->queryCallback)->toTree();
+    }
+
+    /**
      * Variables in tree template.
      *
      * @return array
@@ -243,7 +252,7 @@ SCRIPT;
     {
         return [
             'id'        => $this->elementId,
-            'items'     => $this->model->withQuery($this->queryCallback)->toTree(),
+            'items'     => $this->getItems(),
             'useCreate' => $this->useCreate,
         ];
     }


### PR DESCRIPTION
Sometimes I need to access the items of the tree for further processing, for example for exporting to json, xml.
This pull request add `getItems()` function to access the tree's items from outside.