### PR TITLE
replace getHtmlAttributes() by getRowAttributes() in table.blade.php

### DIFF
--- a/views/grid/table.blade.php
+++ b/views/grid/table.blade.php
@@ -46,7 +46,7 @@
             </tr>
 
             @foreach($grid->rows() as $row)
-            <tr {!! $row->getHtmlAttributes() !!}>
+            <tr {!! $row->getRowAttributes() !!}>
                 <td><input type="checkbox" class="grid-item" data-id="{{ $row->id() }}" /></td>
                 @foreach($grid->columnNames as $name)
                 <td>{!! $row->column($name) !!}</td>


### PR DESCRIPTION
Row.php里面的getHtmlAttributes() 方法好像已经被您替换成了 getRowAttributes()，所以在使用的时候出现了这个报错，然后就改了一下，移交给您。
报错如下：
`
Method Encore\Admin\Grid::__toString() must not throw an exception, caught ErrorException: Call to undefined method Encore\Admin\Grid\Row::getHtmlAttributes() (View: /data/wwwroot/yizhi.ifilm.ltd/resources/views/vendor/admin/grid/table.blade.php)
`
