### PR TITLE
Fix Admin directory location

### DIFF
--- a/config/admin.php
+++ b/config/admin.php
@@ -25,7 +25,7 @@ return [
     /*
      * Laravel-admin install directory.
      */
-    'directory' => app_path('Admin'),
+    'directory' => app_path('Http/Admin'),
 
     /*
      * Laravel-admin html title.


### PR DESCRIPTION
fix #821  管理员目录Http的应该统一放到 `app/Http/Admin` 而非 `app/Admin`