### PR TITLE
add public getId() method for every field

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -207,6 +207,16 @@ class Field implements Renderable
     }
 
     /**
+     * Get the id of the field element.
+     * 
+     * @return array|string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
      * Format the label value.
      *
      * @param array $arguments


### PR DESCRIPTION
Handy if you need control over the fields that might conditionally change in overwritten controllers

In my project there are base controllers that define a set of fields. Other controllers can extend the base controllers but might need extra fields in the form on certain places, remove fields, or apply extra rules to existing fields

Getting the identifier is the minimum requirement to get this working.

eg
```php
        $form->builder()->fields()->transform(function($field){
            if($field->getId()){
                // alter field
            }
        });
```
or 

```php
        $form->builder()->fields()->filter(function($field){
            if($field->getId() == 'optional_field'){
                return false;
            }
            return true;
        });
```