### PR TITLE
make Where queryHash uniquer

### DIFF
--- a/src/Grid/Filter/Where.php
+++ b/src/Grid/Filter/Where.php
@@ -43,7 +43,7 @@ class Where extends AbstractFilter
      *
      * @return string
      */
-    public static function getQueryHash(\Closure $closure, string $label = '')
+    public static function getQueryHash(\Closure $closure, $label = '')
     {
         $reflection = new \ReflectionFunction($closure);
 

--- a/src/Grid/Filter/Where.php
+++ b/src/Grid/Filter/Where.php
@@ -28,8 +28,8 @@ class Where extends AbstractFilter
     {
         $this->where = $query;
 
-        $this->column = static::getQueryHash($query);
         $this->label = $this->formatLabel($label);
+        $this->column = static::getQueryHash($query, $this->label);
         $this->id = $this->formatId($this->column);
 
         $this->setupField();
@@ -39,14 +39,15 @@ class Where extends AbstractFilter
      * Get the hash string of query closure.
      *
      * @param \Closure $closure
+     * @param string   $label
      *
      * @return string
      */
-    public static function getQueryHash(\Closure $closure)
+    public static function getQueryHash(\Closure $closure, string $label = '')
     {
         $reflection = new \ReflectionFunction($closure);
 
-        return md5($reflection->getFileName().$reflection->getStartLine().$reflection->getEndLine());
+        return md5($reflection->getFileName().$reflection->getStartLine().$reflection->getEndLine().$label);
     }
 
     /**
@@ -58,7 +59,7 @@ class Where extends AbstractFilter
      */
     public function condition($inputs)
     {
-        $value = array_get($inputs, static::getQueryHash($this->where));
+        $value = array_get($inputs, static::getQueryHash($this->where, $this->label));
 
         if (is_array($value)) {
             $value = array_filter($value);


### PR DESCRIPTION
I'd like to filter on specific values within a json column.
The column contains translations and I wan't to create af filter per suppported locale.

Content of the column
```
{
	"en": "Howdy!",
	"fr": "Bonjour",
	"nl": "Hallo"
}
```

filter code (simplified):
Since the closure is in a loop, the queryHash (based on location of the Closure) is the same for all filters. Adding the label makes is unique and solves the problem.

<img width="1053" alt="screen shot 2017-05-15 at 12 11 08" src="https://cloud.githubusercontent.com/assets/5647964/26053043/9c8c5a02-3967-11e7-9983-311cd76520fa.png">

```php
// JSON case insensitive search
foreach (config('test.available_locales', []) as $locale => $info) {
    $filter->where(
        function (Builder $query) use ($locale) {
                $query->whereRaw(
                    '`value`->\'$.'.$locale.'\' COLLATE utf8mb4_unicode_ci like ?',
                    ['%'.$this->input.'%']
                );
        },
        'Value ('.$locale.')'
    );
}
```