### PR TITLE
reset $collectedAssets

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -1215,6 +1215,7 @@ class Form
     public static function extend($abstract, $class)
     {
         static::$availableFields[$abstract] = $class;
+        static::$collectedAssets= [];
     }
 
     /**
@@ -1225,6 +1226,7 @@ class Form
     public static function forget($abstract)
     {
         array_forget(static::$availableFields, $abstract);
+        static::$collectedAssets= [];
     }
 
     /**


### PR DESCRIPTION
After adding/forgetting fields, reset the collectedAssets

This way you can call Form::extend() and Form::forget() from any controller and enable/disable fields when needed.
Otherwise,  calling forget and extend would work, but their assets were forgotten