### PR TITLE
Display empty instead of first option when select contains no value

### DIFF
--- a/views/form/select.blade.php
+++ b/views/form/select.blade.php
@@ -6,7 +6,8 @@
 
         @include('admin::form.error')
 
-        <select class="form-control " style="width: 100%;" id="{{$id}}" name="{{$name}}" {!! $attributes !!} >
+        <select class="form-control " style="width: 100%;" id="{{$id}}" name="{{$name}}" {!! $attributes !!}>
+                <option></option>
             @foreach($options as $select => $option)
                 <option value="{{$select}}" {{ $select == old($column, $value) ?'selected':'' }}>{{$option}}</option>
             @endforeach


### PR DESCRIPTION
Allows displaying placeholder (and empty select value) instead of the first option when a select field has no selected option.