### PR TITLE
Fix select field when Clear is requested

### DIFF
--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -19,7 +19,8 @@ class Select extends Field
     public function render()
     {
         if (empty($this->script)) {
-            $this->script = "$(\"#{$this->id}\").select2({allowClear: true, placeholder: \"{$this->placeholder}\"});";
+            $placeholder = isset($this->placeholder) ? $this->placeholder : $this->label;
+            $this->script = "$(\"#{$this->id}\").select2({allowClear: true, placeholder: \"{$placeholder}\"});";
         }
 
         if (is_callable($this->options)) {

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -19,7 +19,7 @@ class Select extends Field
     public function render()
     {
         if (empty($this->script)) {
-            $this->script = "$(\"#{$this->id}\").select2({allowClear: true});";
+            $this->script = "$(\"#{$this->id}\").select2({allowClear: true, placeholder: \"{$this->placeholder}\"});";
         }
 
         if (is_callable($this->options)) {


### PR DESCRIPTION
allowClear option is not enough and throws error if user click the x to clear the select value.
Additional option is needed to work as expected: placeholder.