### PR TITLE
add SelectOrNew component

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @method Field\Checkbox       checkbox($column, $label = '')
  * @method Field\Radio          radio($column, $label = '')
  * @method Field\Select         select($column, $label = '')
+ * @method Field\SelectOrNew    selectOrNew($column, $label = '')
  * @method Field\MultipleSelect multipleSelect($column, $label = '')
  * @method Field\Textarea       textarea($column, $label = '')
  * @method Field\Hidden         hidden($column, $label = '')
@@ -1183,6 +1184,7 @@ class Form
             'radio'             => \Encore\Admin\Form\Field\Radio::class,
             'rate'              => \Encore\Admin\Form\Field\Rate::class,
             'select'            => \Encore\Admin\Form\Field\Select::class,
+            'selectOrNew'       => \Encore\Admin\Form\Field\SelectOrNew::class,
             'slider'            => \Encore\Admin\Form\Field\Slider::class,
             'switch'            => \Encore\Admin\Form\Field\SwitchField::class,
             'text'              => \Encore\Admin\Form\Field\Text::class,

--- a/src/Form/Field/SelectOrNew.php
+++ b/src/Form/Field/SelectOrNew.php
@@ -3,7 +3,7 @@
 namespace Encore\Admin\Form\Field;
 
 /**
- * Select an existing option or type a new one to create it
+ * Select an existing option or type a new one to create it.
  */
 class SelectOrNew extends Select
 {

--- a/src/Form/Field/SelectOrNew.php
+++ b/src/Form/Field/SelectOrNew.php
@@ -68,7 +68,7 @@ class SelectOrNew extends Select
      *
      * @param string $className
      */
-    public function dataModel(string $className)
+    public function dataModel($className)
     {
         $this->dataModel = $className;
     }
@@ -78,7 +78,7 @@ class SelectOrNew extends Select
      *
      * @return $this
      */
-    public function allowClear(bool $allow = true)
+    public function allowClear($allow = true)
     {
         $this->allowClear = $allow;
 

--- a/src/Form/Field/SelectOrNew.php
+++ b/src/Form/Field/SelectOrNew.php
@@ -2,7 +2,6 @@
 
 namespace Encore\Admin\Form\Field;
 
-
 /**
  * Select an existing option or type a new one to create it
  */
@@ -86,7 +85,7 @@ class SelectOrNew extends Select
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function render()
     {

--- a/src/Form/Field/SelectOrNew.php
+++ b/src/Form/Field/SelectOrNew.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Encore\Admin\Form\Field;
+
+
+/**
+ * Select an existing option or type a new one to create it
+ */
+class SelectOrNew extends Select
+{
+    /**
+     * @var bool
+     */
+    protected $optionsSet = false;
+
+    /**
+     * @var bool
+     */
+    protected $allowClear = true;
+
+    /**
+     * @var string|null
+     */
+    protected $dataModel;
+
+    /**
+     * @param array $options
+     *
+     * @return $this|mixed
+     */
+    public function options($options = [])
+    {
+        $this->optionsSet = true;
+
+        return parent::options($options);
+    }
+
+    /**
+     * Fill in the options by selecting the distinct values for the model's column.
+     * Prepends an empty value if $allowClear is true.
+     * Only gets called if no other options are set.
+     *
+     * Does not work in a NestedForm by default. You need to set the dataModel specifically!
+     *
+     * @return $this
+     */
+    public function setDefaultOptions()
+    {
+        $column = $this->column;
+        $model = $this->dataModel ?: $this->form->model();
+        $options = $model::
+        select($column)
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column);
+
+        if ($this->allowClear) {
+            $options->prepend('---', '');
+        }
+
+        $this->options($options);
+
+        return $this;
+    }
+
+    /**
+     * Set the datamodel used to get the default data.
+     *
+     * @param string $className
+     */
+    public function dataModel(string $className)
+    {
+        $this->dataModel = $className;
+    }
+
+    /**
+     * @param bool $allow
+     *
+     * @return $this
+     */
+    public function allowClear(bool $allow = true)
+    {
+        $this->allowClear = $allow;
+
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function render()
+    {
+        if (!$this->optionsSet) {
+            $this->setDefaultOptions();
+        }
+        $allowClear = $this->allowClear ? 'true' : 'false';
+
+        $this->script
+            = "$(\"{$this->getElementClassSelector()}\").select2({
+            allowClear: {$allowClear},
+            tags: true,
+            placeholder: \"{$this->label}\",
+            tokenSeparators: [',']
+        });";
+
+        return parent::render();
+    }
+}

--- a/views/form/selectornew.blade.php
+++ b/views/form/selectornew.blade.php
@@ -1,0 +1,18 @@
+<div class="form-group {!! !$errors->has($errorKey) ?: 'has-error' !!}">
+
+    <label for="{{$id}}" class="col-sm-{{$width['label']}} control-label">{{$label}}</label>
+
+    <div class="col-sm-{{$width['field']}}">
+
+        @include('admin::form.error')
+
+        <select class="form-control {{$class}}" style="width: 100%;" name="{{$name}}"  data-placeholder="{{ $placeholder }}" {!! $attributes !!} >
+            @foreach($options as $select => $option)
+                <option value="{{$select}}" {{ $select == old($column, $value) ?'selected':'' }}>{{$option}}</option>
+            @endforeach
+        </select>
+
+        @include('admin::form.help-block')
+
+    </div>
+</div>


### PR DESCRIPTION
select from existing values for a certain column or add a new one.
if no options are given, options are filled in automatically using the unique values for the given column. By default the selection can be cleared and an empty value is prepended. You can turn it off by calling allowClear(false) on the field.

e.g.
```php
        $form->selectOrNew('salutation’);
```
or specify options yourself

```php
        $form->selectOrNew('salutation')
		->options([
			1 => ‘sir’,
			2 => ‘misses’,
		])
               ->rules('required')
               ->allowClear(false);
```

*allowClear*
there is  method to set wether you can clear the selection or not:
```php
        $form->selectOrNew('salutation’)->allowClear();
```

inside a nestedForm you’ll need to dataModel() to specify on which model to get the default options from (can't seem to find the related model. Please change it if possible)

```php
$form->selectOrNew('city')
                        ->rules('max:50|string')
                        ->attribute('maxlength', 50)
                        ->dataModel(Address::class);

```