### PR TITLE
add lang attribute to <html> tag

### DIFF
--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ config('app.locale') }}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
tell the browser what language we're using. 
Some content might be in another language and this sometimes triggers the auto-translate option in Chrome.