### PR TITLE
Model-form Back button not working in Firefox

### DIFF
--- a/src/Form/Tools.php
+++ b/src/Form/Tools.php
@@ -49,7 +49,7 @@ class Tools implements Renderable
     protected function backButton()
     {
         $script = <<<'EOT'
-$('.form-history-back').on('click', function () {
+$('.form-history-back').on('click', function (event) {
     event.preventDefault();
     history.back(1);
 });


### PR DESCRIPTION
It looks at line 52 'event' must be specified as function parameter in order to work the preventDefault .