### PR TITLE
turn filter modal off by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/css-selector": "2.8.*|3.0.*",
         "fzaninotto/faker": "~1.4",
         "intervention/image": "~2.3",
-        "laravel/browser-kit-testing": "^1.0"
+        "laravel/browser-kit-testing": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -41,7 +41,7 @@ class Filter
      *
      * @var bool
      */
-    protected $useModal = true;
+    protected $useModal = false;
 
     /**
      * If use id filter.


### PR DESCRIPTION
You can only enable it using 'useModal()' so it should be off by default