### PR TITLE
fix grid image not use server url

### DIFF
--- a/src/Grid/Displayers/Image.php
+++ b/src/Grid/Displayers/Image.php
@@ -16,6 +16,8 @@ class Image extends AbstractDisplayer
         return collect((array) $this->value)->filter()->map(function ($path) use ($server, $width, $height) {
             if (url()->isValidUrl($path)) {
                 $src = $path;
+            } elseif ($server) {
+                $src = $server.$path;
             } else {
                 $src = Storage::disk(config('admin.upload.disk'))->url($path);
             }


### PR DESCRIPTION
修复Grid的image方法在显示的时候没有用到自定义的server名字