### PR TITLE
Revert "当自定义的Model中使用__call添加处理方法时，method_exists无法检测到这些方法，所以改为is_callable"

### DIFF
--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -26,7 +26,7 @@ class MultipleSelect extends Select
             return $this->otherKey;
         }
 
-        if (is_callable($this->form->model(), $this->column) &&
+        if (method_exists($this->form->model(), $this->column) &&
             ($relation = $this->form->model()->{$this->column}()) instanceof BelongsToMany
         ) {
             /* @var BelongsToMany $relation */


### PR DESCRIPTION
Reverts z-song/laravel-admin#1185

incorrect syntax and does not work