### PR TITLE
hide back/list buttons on user settings page

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -78,7 +78,14 @@ class AuthController extends Controller
     {
         return Admin::content(function (Content $content) {
             $content->header(trans('admin.user_setting'));
-            $content->body($this->settingForm()->edit(Admin::user()->id));
+            $form = $this->settingForm();
+            $form->tools(
+                function (Form\Tools $tools) {
+                    $tools->disableBackButton();
+                    $tools->disableListButton();
+                }
+            );
+            $content->body($form->edit(Admin::user()->id));
         });
     }
 


### PR DESCRIPTION
- 'list' button returns a 404 since there is no overview of users
- back button only works if you haven't submitted the form

so hiding them is better imo