### PR TITLE
fix(Grid): use all for retrieving all records from collection

### DIFF
--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -342,7 +342,12 @@ class Column
     {
         $originalRow = static::$originalGridData[$key];
 
-        return $callback->bindTo(static::$model->newFromBuilder($originalRow));
+        if (is_array($originalRow)) {
+            // Convert array data to model instance.
+            $originalRow = static::$model->newFromBuilder($originalRow);
+        }
+
+        return $callback->bindTo($originalRow);
     }
 
     /**

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -199,7 +199,7 @@ class Model
                 $collection = call_user_func($this->collectionCallback, $collection);
             }
 
-            $this->data = $collection->toArray();
+            $this->data = $collection->all();
         }
 
         return $this->data;


### PR DESCRIPTION
To retain related models structure, it is better to use all instead of toArray.

Ref: https://laravel.com/docs/5.5/collections#method-toarray