### PR TITLE
fix incorrect log operation

### DIFF
--- a/src/Middleware/LogOperation.php
+++ b/src/Middleware/LogOperation.php
@@ -70,7 +70,7 @@ class LogOperation
             $methods = array_map('strtoupper', $methods);
 
             if ($request->is($except) &&
-                (empty($method) || in_array($request->method(), $methods))) {
+                (empty($methods) || in_array($request->method(), $methods))) {
                 return true;
             }
         }


### PR DESCRIPTION
```
'except' => [
    'admin/auth/logs*',
    'get:admin/*',
],
```
$method does not exist as variable and is therefor always empty
When trying to not log all GET operations, nothing got logged 