### PR TITLE
make select2 multi select orderable

### DIFF
--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -80,6 +80,26 @@ class MultipleSelect extends Select
     {
         $value = (array) $value;
 
-        return array_filter($value);
+        $filtered = array_filter($value);
+        if (!empty($this->orderField)) {
+            $newData = [];
+            foreach ($filtered as $k => $v) {
+                $newData[$v] = [$this->orderField => $k];
+            }
+            return $newData;
+        }
+        return $filtered;
+    }
+
+    /**
+     * Manually ordering
+     *
+     * @return $this
+     */
+    public function usingOrder($orderField)
+    {
+        $this->orderField = $orderField;
+
+        return $this;
     }
 }

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -28,6 +28,16 @@ $("{$this->getElementClassSelector()}").select2({
 EOF;
         }
 
+        if (!empty($this->orderField)) {
+            $this->script .= <<<EOF
+$("{$this->getElementClassSelector()}").on('select2:select', function(e) {
+    var element = $(this).find('[value="' + e.params.data.id + '"]');
+    $(this).append(element);
+    $(this).trigger('change');
+});
+EOF;
+        }
+
         if ($this->options instanceof \Closure) {
             if ($this->form) {
                 $this->options = $this->options->bindTo($this->form->model());
@@ -37,6 +47,7 @@ EOF;
         }
 
         $this->options = array_filter($this->options);
+        $this->options = $this->sortOptions($this->options, $this->value);
 
         return parent::render()->with(['options' => $this->options]);
     }
@@ -186,5 +197,25 @@ $("{$this->getElementClassSelector()}").select2({
 EOT;
 
         return $this;
+    }
+
+    /**
+     * sort select options based on stored value
+     *
+     * @param array $options
+     * @param array $value
+     *
+     * @return array
+     */
+    private function sortOptions($options, $value)
+    {
+        $sorted = [];
+        foreach ($value as $tv) {
+            $sorted[$tv] = $options[$tv];
+            unset($options[$tv]);
+        }
+        $sorted = $sorted + $options;
+
+        return $sorted;
     }
 }


### PR DESCRIPTION
by default select2 multi select will use the plugin's default sorting behavior
this commit makes it possible to do manual ordering

1. on rendering edit page order options
2. on submit edit page sort using submit order