### PR TITLE
修复查询过滤select表单类型无法从api加载数据的问题

### DIFF
--- a/src/Grid/Filter/Presenter/Select.php
+++ b/src/Grid/Filter/Presenter/Select.php
@@ -84,7 +84,7 @@ SCRIPT;
         $this->script = <<<EOT
 
 $.ajax($ajaxOptions).done(function(data) {
-  $("{$this->getElementClass()}").select2({data: data});
+  $(".{$this->getElementClass()}").select2({data: data});
 });
 
 EOT;


### PR DESCRIPTION
修复使用`$filter->equal('column')->select('api/users');`时，jquery选择器无法正确选择对应元素的问题。