### PR TITLE
增加对使用laravel自定义的errors的兼容

### DIFF
--- a/resources/views/partials/error.blade.php
+++ b/resources/views/partials/error.blade.php
@@ -1,20 +1,19 @@
-@if(Session::has('error') || Session::has('errors'))
+@if(Session::has('error'))
     <?php $error = Session::get('error');?>
-    <?php $errors = Session::get('errors');?>
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
-        @if (!empty($error))
         <h4><i class="icon fa fa-ban"></i>{{ array_get($error->get('title'), 0) }}</h4>
-        @endif
-        @if (!empty($error))
         <p>{!!  array_get($error->get('message'), 0) !!}</p>
-        @endif
-        @if (!empty($errors))
-            @foreach($errors->getBags() as $messageBag)
-                @foreach($messageBag->toArray() as $message)
-                    <p>{!!  array_get($message, 0) !!}</p>
-                @endforeach
-            @endforeach
-        @endif
     </div>
+@elseif (Session::has('errors'))
+    <?php $errors = Session::get('errors');?>
+    @if ($errors->hasBag('error'))
+      <div class="alert alert-danger alert-dismissable">
+
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+        @foreach($errors->getBag("error")->toArray() as $message)
+            <p>{!!  array_get($message, 0) !!}</p>
+        @endforeach
+      </div>
+    @endif
 @endif

--- a/resources/views/partials/error.blade.php
+++ b/resources/views/partials/error.blade.php
@@ -1,8 +1,20 @@
-@if(Session::has('error'))
+@if(Session::has('error') || Session::has('errors'))
     <?php $error = Session::get('error');?>
+    <?php $errors = Session::get('errors');?>
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+        @if (!empty($error))
         <h4><i class="icon fa fa-ban"></i>{{ array_get($error->get('title'), 0) }}</h4>
+        @endif
+        @if (!empty($error))
         <p>{!!  array_get($error->get('message'), 0) !!}</p>
+        @endif
+        @if (!empty($errors))
+            @foreach($errors->getBags() as $messageBag)
+                @foreach($messageBag->toArray() as $message)
+                    <p>{!!  array_get($message, 0) !!}</p>
+                @endforeach
+            @endforeach
+        @endif
     </div>
 @endif


### PR DESCRIPTION
相关的问题讨论：
https://github.com/z-song/laravel-admin/issues/1492

在laravel的errors里面增加了一个error为key的MessageBag

所以在controller中，如果我们需要自定义返回的Error(而不是Form表单的错误的时候)，我们可以使用
return Redirect::back()->withInput()->withErrors('城市已经在重跑列表中了', 'error');

这样就可以自定义控制器错误了。

貌似 在兼顾Form的Error不限制在头部，和头部的Error保持title/message结构，这个是一个兼容方案了。
