### PR TITLE
Make Model-grid column editable to display validation messages+Roll back last pull request

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -502,6 +502,8 @@ class Form
     {
         $data = Input::all();
 
+        $isEditable = $this->isEditable($data);
+
         $data = $this->handleEditable($data);
 
         $data = $this->handleFileDelete($data);
@@ -520,7 +522,11 @@ class Form
 
         // Handle validation errors.
         if ($validationMessages = $this->validationMessages($data)) {
-            return back()->withInput()->withErrors($validationMessages);
+            if (!$isEditable) {
+                return back()->withInput()->withErrors($validationMessages);
+            } else {
+                return response()->json(['errors' => array_dot($validationMessages->getMessages())], 422);
+            }
         }
 
         if (($response = $this->prepare($data)) instanceof Response) {
@@ -563,6 +569,22 @@ class Form
         $url = Input::get(Builder::PREVIOUS_URL_KEY) ?: $this->resource(-1);
 
         return redirect($url);
+    }
+
+    /**
+     * Check if request is from editable.
+     *
+     * @param array $input
+     *
+     * @return bool
+     */
+    protected function isEditable(array $input = [])
+    {
+        if (array_key_exists('_editable', $input)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -444,11 +444,7 @@ class Builder
             return '';
         }
 
-        if ($this->mode == self::MODE_EDIT) {
-            $text = trans('admin.save');
-        } else {
-            $text = trans('admin.submit');
-        }
+        $text = trans('admin.submit');
 
         return <<<EOT
 <div class="btn-group pull-right">

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -144,6 +144,7 @@ class Editable extends AbstractDisplayer
 
         $options = json_encode($this->options);
 
+        Admin::script("$.fn.editable.defaults.error = function(data) {var msg = ''; if(data.responseJSON.errors) { $.each(data.responseJSON.errors, function(k, v) { msg += v + '\\n'; });} return msg};");
         Admin::script("$('.$class').editable($options);");
 
         $attributes = [


### PR DESCRIPTION
Grid editable don't process correctly validation. If validation error occur, it is not displayed. The new value is shown in field even it is not saved to DB. The validation messages is never shown.

My changes make grid editable to process correctly validation messages.