### PR TITLE
Fix broken links in quick-start.md

### DIFF
--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -41,4 +41,4 @@ Open `http://localhost:8000/admin/auth/menu`, add menu link and refresh the page
 
 #### 3.build grid and form
 
-The rest needs to be done is open `app/Admin/Contollers/UserController.php`, find `form()` and `grid()` method and write few lines of code with `model-grid` and `model-form`，for more detail, please read [model-grid](/docs/en/model-grid.md) and [model-form](/docs/en/model-form.md).
+The rest needs to be done is open `app/Admin/Contollers/UserController.php`, find `form()` and `grid()` method and write few lines of code with `model-grid` and `model-form`，for more detail, please read [model-grid](/en/model-grid.md) and [model-form](/en/model-form.md).


### PR DESCRIPTION
Fix two broken links in the last paragraph of "Quick Start" (to model-grid and model-form)