### PR TITLE
fix editor bug for dot name

### DIFF
--- a/src/Form/Field/Editor.php
+++ b/src/Form/Field/Editor.php
@@ -12,7 +12,7 @@ class Editor extends Field
 
     public function render()
     {
-        $this->script = "CKEDITOR.replace('{$this->column}');";
+        $this->script = "CKEDITOR.replace('{$this->id}');";
 
         return parent::render();
     }


### PR DESCRIPTION
如果column name中包含点，例如  info.description，会出现问题。已经修复此问题。