### PR TITLE
Add ability to assign validation rules using an Array

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
+use function is_array;
 
 /**
  * Class Field.
@@ -402,6 +403,10 @@ class Field implements Renderable
             $rules = array_filter(explode('|', "{$this->rules}|$rules"));
 
             $this->rules = implode('|', $rules);
+        }
+
+        if(is_array($rules)) {
+            $this->rules = $rules;
         }
 
         $this->validationMessages = $messages;

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
-use function is_array;
 
 /**
  * Class Field.

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -404,7 +404,7 @@ class Field implements Renderable
             $this->rules = implode('|', $rules);
         }
 
-        if(is_array($rules)) {
+        if (is_array($rules)) {
             $this->rules = $rules;
         }
 


### PR DESCRIPTION
Regex validation in Laravel requires arrays instead of strings for the rules definition, as such i've added a simple assignment that checks if the rules are defined as an array and simply sets them if they are.