### PR TITLE
Allow arrays for Rules & Overrideable data for create() and update()

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -317,11 +317,13 @@ class Form
     /**
      * Store a new record.
      *
+     * @param null $inputData
+     *
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|\Illuminate\Http\JsonResponse
      */
-    public function store()
+    public function store($inputData = null)
     {
-        $data = Input::all();
+        $data = $inputData ?: Input::all();
 
         // Handle validation errors.
         if ($validationMessages = $this->validationMessages($data)) {
@@ -495,12 +497,13 @@ class Form
      * Handle update.
      *
      * @param int $id
+     * @param array|null $inputData
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function update($id)
+    public function update($id, $inputData = null)
     {
-        $data = Input::all();
+        $data = $inputData ?: Input::all();
 
         $isEditable = $this->isEditable($data);
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -496,7 +496,7 @@ class Form
     /**
      * Handle update.
      *
-     * @param int $id
+     * @param int        $id
      * @param array|null $inputData
      *
      * @return \Symfony\Component\HttpFoundation\Response

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
+use function is_array;
 
 /**
  * Class Field.
@@ -402,6 +403,10 @@ class Field implements Renderable
             $rules = array_filter(explode('|', "{$this->rules}|$rules"));
 
             $this->rules = implode('|', $rules);
+        }
+
+        if(is_array($rules)) {
+            $this->rules = $rules;
         }
 
         $this->validationMessages = $messages;

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
-use function is_array;
 
 /**
  * Class Field.

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -404,7 +404,7 @@ class Field implements Renderable
             $this->rules = implode('|', $rules);
         }
 
-        if(is_array($rules)) {
+        if (is_array($rules)) {
             $this->rules = $rules;
         }
 


### PR DESCRIPTION
Regex rules in Laravel validation need to be defined using arrays, as such i've added the option to use arrays in the rules field definition.