### PR TITLE
Fix menu select input &nbsp;

### DIFF
--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -234,6 +234,7 @@ trait ModelTree
     public static function selectOptions()
     {
         $options = (new static())->buildSelectOptions();
+        $options = str_replace('&nbsp;', '', $options);
 
         return collect($options)->prepend('Root', 0)->all();
     }


### PR DESCRIPTION
Fixed &nbsp text that appears in parent select input on the admin menu form.