### PR TITLE
BatchActions 设置禁止删除操作时，checkbox选择框缺失

### DIFF
--- a/resources/views/grid/empty-batch-actions.blade.php
+++ b/resources/views/grid/empty-batch-actions.blade.php
@@ -1,0 +1,1 @@
+<input type="checkbox" class="grid-select-all" />&nbsp;

--- a/src/Grid/Tools/BatchActions.php
+++ b/src/Grid/Tools/BatchActions.php
@@ -127,11 +127,12 @@ EOT;
             $this->actions->shift();
         }
 
+        $this->setUpScripts();
+        
         if ($this->actions->isEmpty()) {
-            return '';
+            return view('admin::grid.empty-batch-actions', ['actions' => $this->actions])->render();
         }
 
-        $this->setUpScripts();
 
         return view('admin::grid.batch-actions', ['actions' => $this->actions])->render();
     }

--- a/src/Grid/Tools/BatchActions.php
+++ b/src/Grid/Tools/BatchActions.php
@@ -128,11 +128,10 @@ EOT;
         }
 
         $this->setUpScripts();
-        
-        if ($this->actions->isEmpty()) {
-            return view('admin::grid.empty-batch-actions', ['actions' => $this->actions])->render();
-        }
 
+        if ($this->actions->isEmpty()) {
+            return view('admin::grid.empty-batch-actions')->render();
+        }
 
         return view('admin::grid.batch-actions', ['actions' => $this->actions])->render();
     }


### PR DESCRIPTION
想取消批量删除的操作，但是需要保留选择框

    $grid->tools(function (Grid\Tools $tools) {
            $tools->batch(function (Grid\Tools\BatchActions $actions) {
                $actions->disableDelete();
            });
        });    
设置禁止删除后 action为空 返回了一个空的视图

       if ($this->actions->isEmpty()) {
            return '';
       }
稍稍加了修改返回一个只有checkbox的视图

      if ($this->actions->isEmpty()) {
            return view('admin::grid.empty-batch-actions')->render();
        }