### PR TITLE
fix bug for field rules of form used regex array

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -404,6 +404,12 @@ class Field implements Renderable
             $this->rules = implode('|', $rules);
         }
 
+        if (is_array($rules)) {
+            $thisRuleArr = array_filter(explode('|', $this->rules));
+
+            $this->rules = array_merge($thisRuleArr, $this->rules);
+        }
+
         $this->validationMessages = $messages;
 
         return $this;


### PR DESCRIPTION
在form中使用rules规则进行验证时，增加对array的支持，特定于当使用正则表达式时包含“|”符号会出bug