### PR TITLE
 修复bug：修改表单时，文件组件 重新上传新文件的预览位置 无法覆盖旧文件预览

### DIFF
--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -167,6 +167,7 @@ class File extends Field
      */
     public function render()
     {
+        $this->options(['overwriteInitial' => true]);
         $this->setupDefaultOptions();
 
         if (!empty($this->value)) {
@@ -175,8 +176,6 @@ class File extends Field
 
             $this->setupPreviewOptions();
         }
-
-        $this->options(['overwriteInitial' => true]);
 
         $options = json_encode($this->options);
 


### PR DESCRIPTION
rt：修复bug：修改表单时，文件组件 重新上传新文件的预览位置 无法覆盖旧文件预览