### PR TITLE
图片展示防xss攻击过滤

### DIFF
--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -170,7 +170,7 @@ class File extends Field
         $this->setupDefaultOptions();
 
         if (!empty($this->value)) {
-            $this->attribute('data-initial-preview', addslashes($this->preview()));
+            $this->attribute('data-initial-preview', filter_var($this->preview(),FILTER_VALIDATE_URL));
             $this->attribute('data-initial-caption', $this->initialCaption($this->value));
 
             $this->setupPreviewOptions();


### PR DESCRIPTION

因为很多图片是其他系统上传的，难免会有上传时的xss过滤不严格，报错到数据库的漏洞，为避免xss攻击，做了一个简单的展示过滤，系统能合并到master，毕竟安全还是最重要的，谢谢 或者有更好的展示过滤方法，也可以再次修正一下，谢谢
--


