### PR TITLE
show the date picker on input and icon click

### DIFF
--- a/src/Form/Field/Date.php
+++ b/src/Form/Field/Date.php
@@ -35,8 +35,9 @@ class Date extends Text
     {
         $this->options['format'] = $this->format;
         $this->options['locale'] = config('app.locale');
+        $this->options['allowInputToggle'] = true;
 
-        $this->script = "$('{$this->getElementClassSelector()}').datetimepicker(".json_encode($this->options).');';
+        $this->script = "$('{$this->getElementClassSelector()}').parent().datetimepicker(".json_encode($this->options).');';
 
         $this->prepend('<i class="fa fa-calendar fa-fw"></i>')
             ->defaultAttribute('style', 'width: 110px');


### PR DESCRIPTION
Now date picker appears only by input click, but I think that it's a good idea to show date picker also by icon click (most of my users tried to do that).
(my suggestion https://github.com/z-song/laravel-admin/issues/1820)