### PR TITLE
Better to use ===

### DIFF
--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -259,7 +259,7 @@ trait ModelTree
 
         foreach ($nodes as $node) {
             $node[$this->titleColumn] = $prefix.'&nbsp;'.$node[$this->titleColumn];
-            if ($node[$this->parentColumn] == $parentId) {
+            if ($node[$this->parentColumn] === $parentId) {
                 $children = $this->buildSelectOptions($nodes, $node[$this->getKeyName()], $prefix.$prefix);
 
                 $options[$node[$this->getKeyName()]] = $node[$this->titleColumn];


### PR DESCRIPTION
It may cause wrong result. For example, I find when the id is *string*, the `0 == 'abc'` is `true`. However, this should be `false`.
![laravel-admin-bug](https://user-images.githubusercontent.com/9032435/39068653-98d5d99c-450f-11e8-97f2-5f74c20eab10.jpg)