### PR TITLE
apply pull request#1943 on 1.5 branch: Update UploadField.php. correc…

### DIFF
--- a/src/Form/Field/UploadField.php
+++ b/src/Form/Field/UploadField.php
@@ -288,6 +288,10 @@ trait UploadField
             return $path;
         }
 
+        if ($this->storage) {
+            return $this->storage->url($path);
+        }
+        
         return Storage::disk(config('admin.upload.disk'))->url($path);
     }
 


### PR DESCRIPTION
…t url if defined special disk by disk()

if I defined a special disk and set by disk() method, the URL for file or image in this disk must be not generated by default disk configured by 'admin.upload.disk'.
如果用disk()方法指定了disk, 当生成指向存储空间中的文件或图片的url时，就应该使用新的disk, 而不是原来配置文件中的默认配置。