### PR TITLE
Fix passing array of rules to field

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -401,7 +401,7 @@ class Field implements Renderable
         if (is_array($rules)) {
             $thisRuleArr = array_filter(explode('|', $this->rules));
 
-            $this->rules = array_merge($thisRuleArr, explode('|', $this->rules));
+            $this->rules = array_merge($thisRuleArr, $rules);
         } elseif (is_string($rules)) {
             $rules = array_filter(explode('|', "{$this->rules}|$rules"));
 


### PR DESCRIPTION
Currently, if you pass in an array of rules, they will be skipped completely and not be processed / added. 

This becomes a problem, if you need e.g. extended regexes, which contain a pipe symbol. The regular string handling will always "cut" these regexes (simple explode on the full string by pipe symbol), so working array handling is needed.