### PR TITLE
多选框手动排序，避免提交之后自动排序

### DIFF
--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -80,7 +80,25 @@ class MultipleSelect extends Select
     public function prepare($value)
     {
         $value = (array) $value;
+        $filtered = array_filter($value);
+        if (!empty($this->orderField)) {
+            $newData = [];
+            foreach ($filtered as $k => $v) {
+                $newData[$v] = [$this->orderField => $k];
+            }
+            return $newData;
+        }
+        return $filtered;
+    }
 
-        return array_filter($value);
+    /**
+     * Manually ordering
+     *
+     * @return $this
+     */
+    public function usingOrder($orderField)
+    {
+        $this->orderField = $orderField;
+        return $this;
     }
 }

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -330,10 +330,10 @@ EOF;
      */
     private function sortOptions($options, $value)
     {
-        $sorted = [];
         if (empty($value) || !is_array($value)) {
-            return $sorted;
+            return $options;
         }
+        $sorted = [];
         foreach ($value as $tv) {
             $sorted[$tv] = $options[$tv];
             unset($options[$tv]);

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -293,6 +293,15 @@ EOT;
         if (empty($this->script)) {
             $this->script = "$(\"{$this->getElementClassSelector()}\").select2($configs);";
         }
+        if (!empty($this->orderField)) {
+            $this->script .= <<<EOF
+$("{$this->getElementClassSelector()}").on('select2:select', function(e) {
+    var element = $(this).find('[value="' + e.params.data.id + '"]');
+    $(this).append(element);
+    $(this).trigger('change');
+});
+EOF;
+        }
 
         if ($this->options instanceof \Closure) {
             if ($this->form) {
@@ -303,10 +312,33 @@ EOT;
         }
 
         $this->options = array_filter($this->options);
+        $this->options = $this->sortOptions($this->options, $this->value);
 
         return parent::render()->with([
             'options' => $this->options,
             'groups'  => $this->groups,
         ]);
+    }
+
+    /**
+     * sort select options based on stored value
+     *
+     * @param array $options
+     * @param array $value
+     *
+     * @return array
+     */
+    private function sortOptions($options, $value)
+    {
+        $sorted = [];
+        if (empty($value) || !is_array($value)) {
+            return $sorted;
+        }
+        foreach ($value as $tv) {
+            $sorted[$tv] = $options[$tv];
+            unset($options[$tv]);
+        }
+        $sorted = $sorted + $options;
+        return $sorted;
     }
 }


### PR DESCRIPTION
目前在多选框中选择多个标签保存由于 select2 的特性会自动重新排序导致多个标签在后台保存的顺序和当时填入的顺序不一致，这个 patch 可以保证在 multiselect 框中按什么顺序提交标签在后台就看到对应顺序的标签

books:

| id  | name |
| --- | ---- |
| 1   | 亮剑 |

tags:

| id  | name |
| --- | ---- |
| 1   | 武侠 |
| 2   | 军事 |
| 3   | 剧情 |
| 4   | 悬疑 |

book_tag:

| book_id | tag_id | ranking |
| ------- | ------ | ------- |
| 1       | 4      | 1       |
| 1       | 1      | 2       |
| 1       | 3      | 3       |

比如说建上面 3 张表，每本书可以关联多个标签，目前通过 select2 的 multiselect 插件，是没法控制顺序的，因为 select2 的 bug 导致提交时会乱序保存，要实现顺序保存可以在关联表中新增`ranking`字段用来保存每个关系的顺序，具体使用例子见下：

在对应的 form 方法中使用下面这行代码，主要是通过 usingOrder('ranking')来指定排序字段

```php
$form->multipleSelect('tag', '标签')->options(Tag::all()->pluck('name', 'id'))->usingOrder('ranking');
```

保存之后就会发现 ranking 被自动写入，而且是从 0 开始自增的
