### PR TITLE
Filter查询过滤增加不需要的查询字段，Select二级联动ajax分页加载

### DIFF
--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -313,7 +313,7 @@ EOT;
     /**
      * Select Level 2 linkage, support ajax paging.
      *
-     * @param string $field    parent field name
+     * @param string $field     parent field name
      * @param string $sourceUrl resource route
      * @param string $idField
      * @param string $textField

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -78,6 +78,11 @@ class Filter
     protected $filterModalId = 'filter-modal';
 
     /**
+     * @var bool
+     */
+    protected $filterCondition = false;
+
+    /**
      * Create a new filter instance.
      *
      * @param Model $model
@@ -89,6 +94,18 @@ class Filter
         $pk = $this->model->eloquent()->getKeyName();
 
         $this->equal($pk, strtoupper($pk));
+    }
+
+    /**
+     * Filter unwanted query conditions.
+     *
+     * @param array $attributes
+     * @return $this
+     */
+    public function setNotWhere($attributes = [])
+    {
+        $this->filterCondition = $attributes;
+        return $this;
     }
 
     /**

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -171,7 +171,7 @@ class Filter
                 unset($input[$attr]);
             }
         }
-        
+
         $inputs = array_dot($input);
 
         $inputs = array_filter($inputs, function ($input) {

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -100,11 +100,13 @@ class Filter
      * Filter unwanted query conditions.
      *
      * @param array $attributes
+     *
      * @return $this
      */
     public function setNotWhere($attributes = [])
     {
         $this->filterCondition = $attributes;
+
         return $this;
     }
 
@@ -162,7 +164,15 @@ class Filter
      */
     public function conditions()
     {
-        $inputs = array_dot(Input::all());
+        $input = Input::all();
+
+        if ($this->filterCondition) {
+            foreach ($this->filterCondition as $attr) {
+                unset($input[$attr]);
+            }
+        }
+        
+        $inputs = array_dot($input);
 
         $inputs = array_filter($inputs, function ($input) {
             return $input !== '' && !is_null($input);


### PR DESCRIPTION
#### Filter查询过滤增加不需要的查询字段
- 当我在使用grid查询过滤时，某些字段是需要展示输入框的，但是不需要在当前Model里面做查询操作。
`Encore\Admin\Grid\Filter.php` 添加一个过滤where的方法`setNotWhere`,使用如下:
```
	$grid->filter(function ($filter) {
		 $filter->setNotWhere(['type', 'id']);
		});
```

#### Select二级联动ajax分页加载
- 默认select ajax分页加载只支持一级，二级不支持。
- `Encore\Admin\Form\Field\Select.php` 添加ajaxLoad方法，支持这个功能



