### PR TITLE
LogOperation path 字段截取前255字符

### DIFF
--- a/src/Middleware/LogOperation.php
+++ b/src/Middleware/LogOperation.php
@@ -22,7 +22,7 @@ class LogOperation
         if ($this->shouldLogOperation($request)) {
             $log = [
                 'user_id' => Admin::user()->id,
-                'path'    => $request->path(),
+                'path'    => substr($request->path(), 0, 255),
                 'method'  => $request->method(),
                 'ip'      => $request->getClientIp(),
                 'input'   => json_encode($request->input()),


### PR DESCRIPTION
admin_operation_log 表 path 字段长度是 255,一般情况下够用，但在批量删除时可能超出，如：
post /admin/auth/logs/58,57,56,55,54,53,52,51,50,49,48,47,46,45,44,43,42,41,39,38
假如主键 id 偏大或批量删除的数据过多时便超出报错了，故应把 path 截取前 255 位作为简易的解决方式:
'path'    => substr($request->path(), 0, 255),