### PR TITLE
Form/Field/UploadField: check for disk existence only if Exception is thrown

### DIFF
--- a/src/Form/Field/UploadField.php
+++ b/src/Form/Field/UploadField.php
@@ -134,16 +134,23 @@ trait UploadField
      */
     public function disk($disk)
     {
-        if (!array_key_exists($disk, config('filesystems.disks'))) {
-            $error = new MessageBag([
-                'title'   => 'Config error.',
-                'message' => "Disk [$disk] not configured, please add a disk config in `config/filesystems.php`.",
-            ]);
 
-            return session()->flash('error', $error);
-        }
+	try {
 
-        $this->storage = Storage::disk($disk);
+            $this->storage = Storage::disk($disk);
+
+	} catch (\Exception $e) {
+	    if (!array_key_exists($disk, config('filesystems.disks'))) {
+                $error = new MessageBag([
+                    'title'   => 'Config error.',
+                    'message' => "Disk [$disk] not configured, please add a disk config in `config/filesystems.php`.",
+                ]);
+
+                return session()->flash('error', $error);
+            }
+
+	    throw $e;
+	}
 
         return $this;
     }


### PR DESCRIPTION
patch to fix compatibility with packages that setup storage at run time (like hyn/multi-tenant)