### PR TITLE
custom format form column data when edit

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -186,6 +186,13 @@ class Field implements Renderable
     protected $horizontal = true;
 
     /**
+     * column data format
+     *
+     * @var Closure
+     */
+    protected $customFormat = null;
+
+    /**
      * Field constructor.
      *
      * @param $column
@@ -314,19 +321,21 @@ class Field implements Renderable
         }
 
         $this->value = array_get($data, $this->column);
-        if (isset($this->format) && $this->format instanceof \Closure) {
-            $this->value = call_user_func($this->format , $this->value);
+        if (isset($this->customFormat) && $this->customFormat instanceof \Closure) {
+            $this->value = call_user_func($this->customFormat, $this->value);
         }
     }
 
     /**
      * [custom format form column data when edit]
+     *
      * @param  Closure $call
+     *
      * @return [null]
      */
-    public function format(\Closure $call)
+    public function customFormat(\Closure $call)
     {
-        $this->format = $call;
+        $this->customFormat = $call;
     }
 
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -194,7 +194,7 @@ class Field implements Renderable
      * @var Closure
      */
     protected $customFormat = null;
-  
+
     /**
      * @var bool
      */

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -314,7 +314,21 @@ class Field implements Renderable
         }
 
         $this->value = array_get($data, $this->column);
+        if (isset($this->format) && $this->format instanceof \Closure) {
+            $this->value = call_user_func($this->format , $this->value);
+        }
     }
+
+    /**
+     * [custom format form column data when edit]
+     * @param  Closure $call
+     * @return [null]
+     */
+    public function format(\Closure $call)
+    {
+        $this->format = $call;
+    }
+
 
     /**
      * Set original value to the field.

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -186,7 +186,7 @@ class Field implements Renderable
     protected $horizontal = true;
 
     /**
-     * column data format
+     * column data format.
      *
      * @var Closure
      */
@@ -327,9 +327,9 @@ class Field implements Renderable
     }
 
     /**
-     * [custom format form column data when edit]
+     * custom format form column data when edit.
      *
-     * @param  Closure $call
+     * @param Closure $call
      *
      * @return [null]
      */
@@ -337,7 +337,6 @@ class Field implements Renderable
     {
         $this->customFormat = $call;
     }
-
 
     /**
      * Set original value to the field.


### PR DESCRIPTION
发现很多人需要编辑表单的时候对数据格式化显示
@z-song 给出的解决是model里面加方法
`getColumnNameAttribute`
这样前台的显示也一并被格式化了。
实际情况是，前台需要显示和数据库里保存的数据一致，而编辑人员看到的是格式化之前的数据。
比如说价格，数据库保存的和前端显示的都是以元为单位(显示位置多，就可以不用一一转化，直接取数据库的值显示)，而后台人员看到的是以分为单位。
所以上面的方法就不适用了，找了下发现挺多人问同样的问题却都没有合适的解决，就改了下。
usage:
`$form->text('subhead', '副标题')->rules('required')->format(function($value) {
      return str_replace('-', ' ', $value);
 });`