### PR TITLE
admin protect

### DIFF
--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -132,7 +132,7 @@ class UserController extends Controller
      */
     public function update($id)
     {
-        if($id == 1 && Admin::user()->id != 1){
+        if ($id == 1 && Admin::user()->id != 1) {
             return back();
         }
 
@@ -149,21 +149,21 @@ class UserController extends Controller
     public function destroy($id)
     {
         $ids = explode(',', $id);
-        if(in_array(1, $ids)){
+        if (in_array(1, $ids)) {
             return response()->json([
-                'status'  => false,
+                'status' => false,
                 'message' => trans('admin.delete_failed'),
             ]);
         }
 
         if ($this->form()->destroy($id)) {
             return response()->json([
-                'status'  => true,
+                'status' => true,
                 'message' => trans('admin.delete_succeeded'),
             ]);
         } else {
             return response()->json([
-                'status'  => false,
+                'status' => false,
                 'message' => trans('admin.delete_failed'),
             ]);
         }

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -122,4 +122,50 @@ class UserController extends Controller
             });
         });
     }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param int $id
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function update($id)
+    {
+        if($id == 1 && Admin::user()->id != 1){
+            return back();
+        }
+
+        return $this->form()->update($id);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param int $id
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        $ids = explode(',', $id);
+        if(in_array(1, $ids)){
+            return response()->json([
+                'status'  => false,
+                'message' => trans('admin.delete_failed'),
+            ]);
+        }
+
+        if ($this->form()->destroy($id)) {
+            return response()->json([
+                'status'  => true,
+                'message' => trans('admin.delete_succeeded'),
+            ]);
+        } else {
+            return response()->json([
+                'status'  => false,
+                'message' => trans('admin.delete_failed'),
+            ]);
+        }
+    }
 }


### PR DESCRIPTION
后台用户管理里有对 id 为 1 的帐号进行了防删保护，可理解为对超级管理员的保护，但只是前端上的防护，用户还是可以通过伪造表单删除超级管理员，因为很多应用场景需要其它管理员也有帐号管理的权限，所以不适合用权限管理功能来防范。出于严谨考虑，应在后端对删除和更新操作进行过滤，我的规则是：
1，超管不可删除，防止误删无法登陆
2，非超管不可对超管进行编辑
更新操作由于没有合适的字段提示，所以直接返回无提示，能改进的话更好
