### PR TITLE
Upgrade  removeRule method  

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -435,8 +435,8 @@ class Field implements Renderable
         return $this->rules;
     }
 
-    /**
-     * Remove a specific rule.
+     /**
+     * Remove a specific rule by keyword.
      *
      * @param string $rule
      *
@@ -444,7 +444,8 @@ class Field implements Renderable
      */
     protected function removeRule($rule)
     {
-        $this->rules = str_replace($rule, '', $this->rules);
+        $pattern = "/{$rule}[^\|]?(\||$)/";
+        $this->rules = preg_replace($pattern, '', $this->rules, -1);
     }
 
     /**


### PR DESCRIPTION
Upgrade  removeRule method  for able to  remove a rule by keyword.
For example,  In Form/Field/File line 73 call $this->removeRule('required');
If this field has a rule  like  below , use the old method    
required_unless|regex:/^\d+$/|min:10
old method result: _unless|regex:/^\d+$/|min:10    and will cause an error then validator make!
After upgrade : regex:/^\d+$/|min:10
From Issue: https://github.com/z-song/laravel-admin/issues/2186