### PR TITLE
Bug fix MultipleSelect.

### DIFF
--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -48,7 +48,10 @@ class MultipleSelect extends Select
         }
 
         if (is_array($relations)) {
-            if (is_string(current($relations))) {
+            if(is_null(current($relations))){
+                $this->value = null;
+            }
+            else if (is_string(current($relations))) {
                 $this->value = $relations;
             } else {
                 foreach ($relations as $relation) {
@@ -67,7 +70,10 @@ class MultipleSelect extends Select
         }
 
         if (is_array($relations)) {
-            if (is_string(current($relations))) {
+            if(is_null(current($relations))){
+                $this->original = null;
+            }
+            else if (is_string(current($relations))) {
                 $this->original = $relations;
             } else {
                 foreach ($relations as $relation) {


### PR DESCRIPTION
In form function, if developer adds embeds>checkbox, and something has error in form display (ex, required error other field), throw Exception.
Because in MultipleSelect.php>fill function, "current($relations)" value is null with embeds>checkbox field if user doesn't select, so "is_string(current($relations))" is false.
Then, calling else block, $this->getOtherKey() is error because almost embeds>checkbox field is no relation.

So I added checking "is_null(current($relations))". if current($relations) is null, $this->value = null.