### PR TITLE
表单支持定义多个回调

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -90,23 +90,23 @@ class Form implements Renderable
     /**
      * Submitted callback.
      *
-     * @var Closure
+     * @var Closure[]
      */
-    protected $submitted;
+    protected $submitted = [];
 
     /**
      * Saving callback.
      *
-     * @var Closure
+     * @var Closure[]
      */
-    protected $saving;
+    protected $saving = [];
 
     /**
      * Saved callback.
      *
-     * @var Closure
+     * @var Closure[]
      */
-    protected $saved;
+    protected $saved = [];
 
     /**
      * Data for save to current model from input.
@@ -331,7 +331,7 @@ class Form implements Renderable
             $this->updateRelation($this->relations);
         });
 
-        if (($response = $this->complete($this->saved)) instanceof Response) {
+        if (($response = $this->callSaved()) instanceof Response) {
             return $response;
         }
 
@@ -433,8 +433,10 @@ class Form implements Renderable
      */
     protected function callSubmitted()
     {
-        if ($this->submitted instanceof Closure) {
-            return call_user_func($this->submitted, $this);
+        foreach ($this->submitted as $func) {
+            if ($func instanceof Closure && ($ret = call_user_func($func, $this)) instanceof Response) {
+                return $ret;
+            }
         }
     }
 
@@ -445,22 +447,24 @@ class Form implements Renderable
      */
     protected function callSaving()
     {
-        if ($this->saving instanceof Closure) {
-            return call_user_func($this->saving, $this);
+        foreach ($this->saving as $func) {
+            if ($func instanceof Closure && ($ret = call_user_func($func, $this)) instanceof Response) {
+                return $ret;
+            }
         }
     }
 
     /**
      * Callback after saving a Model.
      *
-     * @param Closure|null $callback
-     *
      * @return mixed|null
      */
-    protected function complete(Closure $callback = null)
+    protected function callSaved()
     {
-        if ($callback instanceof Closure) {
-            return $callback($this);
+        foreach ($this->saved as $func) {
+            if ($func instanceof Closure && ($ret = call_user_func($func, $this)) instanceof Response) {
+                return $ret;
+            }
         }
     }
 
@@ -519,7 +523,7 @@ class Form implements Renderable
             $this->updateRelation($this->relations);
         });
 
-        if (($result = $this->complete($this->saved)) instanceof Response) {
+        if (($result = $this->callSaved()) instanceof Response) {
             return $result;
         }
 
@@ -865,7 +869,7 @@ class Form implements Renderable
      */
     public function submitted(Closure $callback)
     {
-        $this->submitted = $callback;
+        $this->submitted[] = $callback;
     }
 
     /**
@@ -877,7 +881,7 @@ class Form implements Renderable
      */
     public function saving(Closure $callback)
     {
-        $this->saving = $callback;
+        $this->saving[] = $callback;
     }
 
     /**
@@ -889,7 +893,7 @@ class Form implements Renderable
      */
     public function saved(Closure $callback)
     {
-        $this->saved = $callback;
+        $this->saved[] = $callback;
     }
 
     /**


### PR DESCRIPTION
1. `Form::complete()` 方法更名为 `callSaved()`，与 `callSubmitted()`、`callSaving()` 统一命名；
2. 之前如果多次调用 `$form->saved(function() {})` 只有最后一个回调会生效，现在都会生效。