### PR TITLE
图片 remove 按钮问题

### DIFF
--- a/src/Form/Field/UploadField.php
+++ b/src/Form/Field/UploadField.php
@@ -65,8 +65,15 @@ trait UploadField
             'browseLabel'          => trans('admin.browse'),
             'showRemove'           => false,
             'showUpload'           => false,
+            'uploadUrl'            => '#',
+            'fileActionSettings'   => [
+                'showUpload' => false,
+                'showRemove' => $this->removable,
+                'showZoom'   => true,
+            ],
+            'defaultPreviewContent' => '（可拖动图片到此）',
 //            'initialCaption'       => $this->initialCaption($this->value),
-            'deleteExtraData'      => [
+            'deleteExtraData' => [
                 $this->formatName($this->column) => static::FILE_DELETE_FLAG,
                 static::FILE_DELETE_FLAG         => '',
                 '_token'                         => csrf_token(),


### PR DESCRIPTION
解决 form 图片上传设置 removeable() 方法后，若原有图片内容为空时，选择新图片展示后不会显示 remove 按钮