### PR TITLE
Fix - Label support for one-to-one relations on Show

### DIFF
--- a/src/Show.php
+++ b/src/Show.php
@@ -391,7 +391,7 @@ class Show implements Renderable
                 return $this->addRelation($method, $arguments[1], $arguments[0]);
             }
 
-            return $this->addField($method)->setRelation(snake_case($method));
+            return $this->addField($method, $arguments[0])->setRelation(snake_case($method));
         }
 
         if ($relation    instanceof HasMany


### PR DESCRIPTION
$show->sinif('Sınıf'); // Show label as "Sinif"
After this
$show->sinif('Sınıf') // Show label as "Sınıf"