### PR TITLE
Fix #1917 Tags 增加多对多关联的支持

### DIFF
--- a/resources/views/form/tags.blade.php
+++ b/resources/views/form/tags.blade.php
@@ -8,8 +8,8 @@
 
         <select class="form-control {{$class}}" style="width: 100%;" name="{{$name}}[]" multiple="multiple" data-placeholder="{{ $placeholder }}" {!! $attributes !!} >
 
-            @foreach($options as $option)
-                <option value="{{$option}}" {{ in_array($option, $value) ? 'selected' : '' }}>{{$option}}</option>
+            @foreach($options as $key => $option)
+                <option value="{{ $keyAsValue ? $key : $option}}" {{ in_array($option, $value) ? 'selected' : '' }}>{{$option}}</option>
             @endforeach
 
         </select>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -13,8 +13,6 @@
 
     <!-- Theme style -->
     <link rel="stylesheet" href="{{ admin_asset("/vendor/laravel-admin/AdminLTE/dist/css/skins/" . config('admin.skin') .".min.css") }}">
-
-    {!! Admin::css() !!}
     <link rel="stylesheet" href="{{ admin_asset("/vendor/laravel-admin/laravel-admin/laravel-admin.css") }}">
     <link rel="stylesheet" href="{{ admin_asset("/vendor/laravel-admin/nprogress/nprogress.css") }}">
     <link rel="stylesheet" href="{{ admin_asset("/vendor/laravel-admin/sweetalert2/dist/sweetalert2.css") }}">
@@ -23,6 +21,7 @@
     <link rel="stylesheet" href="{{ admin_asset("/vendor/laravel-admin/bootstrap3-editable/css/bootstrap-editable.css") }}">
     <link rel="stylesheet" href="{{ admin_asset("/vendor/laravel-admin/google-fonts/fonts.css") }}">
     <link rel="stylesheet" href="{{ admin_asset("/vendor/laravel-admin/AdminLTE/dist/css/AdminLTE.min.css") }}">
+    {!! Admin::css() !!}
 
     <!-- REQUIRED JS SCRIPTS -->
     <script src="{{ admin_asset ("/vendor/laravel-admin/AdminLTE/plugins/jQuery/jQuery-2.1.4.min.js") }}"></script>

--- a/src/Form/Field/Tags.php
+++ b/src/Form/Field/Tags.php
@@ -81,7 +81,7 @@ class Tags extends Field
         }
 
         $this->visibleColumn = $visibleColumn;
-        $this->key           = $key;
+        $this->key = $key;
 
         return $this;
     }
@@ -100,7 +100,7 @@ class Tags extends Field
         }
 
         if ($options instanceof Collection) {
-            $options = $options->pluck($this->visibleColumn, $this->key) ?? $options;
+            $options = $options->pluck($this->visibleColumn, $this->key)->toArray();
         }
 
         if ($options instanceof Arrayable) {
@@ -113,9 +113,10 @@ class Tags extends Field
     }
 
     /**
-     * Set save Action
+     * Set save Action.
      *
      * @param \Closure $saveAction
+     *
      * @return $this
      */
     public function saving(\Closure $saveAction)
@@ -179,7 +180,7 @@ class Tags extends Field
 
         return parent::render()->with([
             'options'    => $options,
-            'keyAsValue' => $this->keyAsValue
+            'keyAsValue' => $this->keyAsValue,
         ]);
     }
 }

--- a/src/Form/Field/Tags.php
+++ b/src/Form/Field/Tags.php
@@ -3,7 +3,9 @@
 namespace Encore\Admin\Form\Field;
 
 use Encore\Admin\Form\Field;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 class Tags extends Field
 {
@@ -11,6 +13,26 @@ class Tags extends Field
      * @var array
      */
     protected $value = [];
+
+    /**
+     * @var bool
+     */
+    protected $keyAsValue = false;
+
+    /**
+     * @var string
+     */
+    protected $visibleColumn = null;
+
+    /**
+     * @var string
+     */
+    protected $key = null;
+
+    /**
+     * @var \Closure
+     */
+    protected $saveAction = null;
 
     /**
      * @var array
@@ -33,6 +55,10 @@ class Tags extends Field
     {
         $this->value = array_get($data, $this->column);
 
+        if (is_array($this->value) && $this->keyAsValue) {
+            $this->value = array_column($this->value, $this->visibleColumn, $this->key);
+        }
+
         if (is_string($this->value)) {
             $this->value = explode(',', $this->value);
         }
@@ -41,12 +67,77 @@ class Tags extends Field
     }
 
     /**
+     * Set visible column and key of data.
+     *
+     * @param $visibleColumn
+     * @param $key
+     *
+     * @return $this
+     */
+    public function pluck($visibleColumn, $key)
+    {
+        if (!empty($visibleColumn) && !empty($key)) {
+            $this->keyAsValue = true;
+        }
+
+        $this->visibleColumn = $visibleColumn;
+        $this->key           = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set the field options.
+     *
+     * @param array|Collection|Arrayable $options
+     *
+     * @return $this|Field
+     */
+    public function options($options = [])
+    {
+        if (!$this->keyAsValue) {
+            return parent::options($options);
+        }
+
+        if ($options instanceof Collection) {
+            $options = $options->pluck($this->visibleColumn, $this->key) ?? $options;
+        }
+
+        if ($options instanceof Arrayable) {
+            $options = $options->toArray();
+        }
+
+        $this->options = $options + $this->options;
+
+        return $this;
+    }
+
+    /**
+     * Set save Action
+     *
+     * @param \Closure $saveAction
+     * @return $this
+     */
+    public function saving(\Closure $saveAction)
+    {
+        $this->saveAction = $saveAction;
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function prepare($value)
     {
+        $value = array_filter($value, 'strlen');
+
+        if ($this->keyAsValue) {
+            return is_null($this->saveAction) ? $value : ($this->saveAction)($value);
+        }
+
         if (is_array($value) && !Arr::isAssoc($value)) {
-            $value = implode(',', array_filter($value, 'strlen'));
+            $value = implode(',', $value);
         }
 
         return $value;
@@ -80,8 +171,15 @@ class Tags extends Field
             tokenSeparators: [',']
         });";
 
+        if ($this->keyAsValue) {
+            $options = $this->value + $this->options;
+        } else {
+            $options = array_unique(array_merge($this->value, $this->options));
+        }
+
         return parent::render()->with([
-            'options' => array_unique(array_merge($this->value, $this->options)),
+            'options'    => $options,
+            'keyAsValue' => $this->keyAsValue
         ]);
     }
 }


### PR DESCRIPTION
解决 issue #1917

原来的 Tags 不支持多对多关联，此 PR 增加了多对多关联的支持并且**兼容原来 Tags 的用法**。

`Tags` 类增加了 `pluck` 方法，比如在博客系统中，文章的标签与文章属于多对多关联的情况下，使用方法如下：

`Post`  的 `tags` 方法

```php
    public function tags()
    {
        return $this->belongsToMany('App\Models\Tag', 'post_tag', 'post_id', 'tag_id');
    }
```
`PostController` 的 `form` 方法里

```php
// 修改了 options 方法，在调用了 Tags 的 pluck 方法后，
// 如果 options 方法传入了 Collection 对象则会自动调用 Collection 的 pluck 方法，更加简洁。
$form->tags('tags', 'tags')
    ->pluck('name', 'id')
    ->options(Tag::all());
``` 

在这个示例中，HTML 结果如下：

```html
<select class="form-control tags" style="width: 100%;" name="tags[]" multiple="multiple" data-placeholder="输入 tags"  >

<option value="1" selected>php</option>
<option value="2" selected>js</option>
<option value="3" >html</option>
<option value="4" >css</option>

</select>
```

示例图片：

![tags](https://preview.ibb.co/h5c1qU/20180912100838.png)

其中 `option` 的 `value` 属性被指定的 `id`，显示内容指定为 `name`

---

此外 `Tags` 类增加了 `saving` 方法，设置一个回调函数并在 `prepare` 方法内调用。以此实现自定义「在用户输入了不存在的标签」时采用的策略。

比如在更新了博客文章时，添加了不存在的标签。可以用以下代码自动创建新的标签。

**saving 方法接收 「参数为 Tags 提交值，返回值为修改后的 Tags 提交值」的闭包**

```php
        $form->tags('tags', 'tags')
            ->pluck('name', 'id')
            ->options(Tag::all())
            ->saving(function ($value) {
                // 获取全部标签 ID
                $allTagId = Tag::query()->pluck('id')->toArray();
                // 当前提交的有效标签 ID
                $newValue = array_intersect($allTagId, $value);
                // 创建 tags 表中不存在的记录，并将其 ID 加入返回数组
                foreach (array_diff($value, $allTagId) as $newTagName) {
                    $tag = Tag::create([
                        'name' => $newTagName,
                        'slug' => 'demo'
                    ]);
                    $newValue[] = $tag->id;
                }
                return $newValue;
            });
```