### PR TITLE
fix #2490 Show 页面XSS漏洞

### DIFF
--- a/resources/views/show/field.blade.php
+++ b/resources/views/show/field.blade.php
@@ -5,11 +5,19 @@
         <div class="box box-solid box-default no-margin box-show">
             <!-- /.box-header -->
             <div class="box-body">
-                {!! $content !!}&nbsp;
+                @if($escape)
+                    {{ $content }}
+                @else
+                    {!! $content !!}
+                @endif
             </div><!-- /.box-body -->
         </div>
         @else
-            {!! $content !!}
+            @if($escape)
+                {{ $content }}
+            @else
+                {!! $content !!}
+            @endif
         @endif
     </div>
 </div>

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -37,6 +37,13 @@ class Field implements Renderable
     protected $label;
 
     /**
+     * Escape field value or not.
+     *
+     * @var bool
+     */
+    protected $escape = true;
+
+    /**
      * Field value.
      *
      * @var mixed
@@ -365,6 +372,20 @@ HTML;
     }
 
     /**
+     * Set escape or not for this field.
+     *
+     * @param bool $escape
+     *
+     * @return $this
+     */
+    public function setEscape($escape)
+    {
+        $this->escape = $escape;
+
+        return $this;
+    }
+
+    /**
      * Set value for this field.
      *
      * @param Model $model
@@ -429,6 +450,7 @@ HTML;
     {
         return [
             'content'   => $this->value,
+            'escape'    => $this->escape,
             'label'     => $this->getLabel(),
             'wrapped'   => $this->wrapped,
         ];


### PR DESCRIPTION
修复 issue #2490 

漏洞原因是因为 `field.php` 中的内容采用了 `{!! $content !!}` 输出原内容而未经转义。经过本人考量直接将全部字段内容转义不合适，因为部分内容需要HTML格式显示。所以修改了 `Field.php` 这个类，增加了 `escape` 属性，且默认值为 `true` 并且修改了模板。实现了普通字段默认转义 HTML 的功能，同时还可以通过 `setEscape` 方法设置不转义。

示例如下：
``` php
    protected function detail($id)
    {
        $show = new Show(Post::findOrFail($id));

        $show->id('Id');
        // title 字段值默认被转义
        $show->title('Title');
        // content 字段的值不会被转义
        $show->content('Content')->setEscape(false);

        return $show;
    }
```