### PR TITLE
fix #2485 #1572 部分 Displayer 支持传递闭包参数

### DIFF
--- a/src/Grid/Displayers/Checkbox.php
+++ b/src/Grid/Displayers/Checkbox.php
@@ -3,16 +3,25 @@
 namespace Encore\Admin\Grid\Displayers;
 
 use Encore\Admin\Admin;
+use Illuminate\Contracts\Support\Arrayable;
 
 class Checkbox extends AbstractDisplayer
 {
     public function display($options = [])
     {
+        if ($options instanceof \Closure) {
+            $options = $options->call($this, $this->row);
+        }
+
         $radios = '';
         $name = $this->column->getName();
 
         if (is_string($this->value)) {
             $this->value = explode(',', $this->value);
+        }
+
+        if ($this->value instanceof Arrayable) {
+            $this->value = $this->value->toArray();
         }
 
         foreach ($options as $value => $label) {

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -58,6 +58,10 @@ class Editable extends AbstractDisplayer
      */
     public function select($options = [])
     {
+        if ($options instanceof \Closure) {
+            $options = $options->call($this, $this->row);
+        }
+
         $source = [];
 
         foreach ($options as $key => $value) {

--- a/src/Grid/Displayers/Radio.php
+++ b/src/Grid/Displayers/Radio.php
@@ -8,6 +8,10 @@ class Radio extends AbstractDisplayer
 {
     public function display($options = [])
     {
+        if ($options instanceof \Closure) {
+            $options = $options->call($this, $this->row);
+        }
+
         $radios = '';
         $name = $this->column->getName();
 

--- a/src/Grid/Displayers/Select.php
+++ b/src/Grid/Displayers/Select.php
@@ -8,6 +8,10 @@ class Select extends AbstractDisplayer
 {
     public function display($options = [])
     {
+        if ($options instanceof \Closure) {
+            $options = $options->call($this, $this->row);
+        }
+
         $name = $this->column->getName();
 
         $class = "grid-select-{$name}";


### PR DESCRIPTION
修复 issue #2485 #1572

现在 `Grid` 的 `Select`、`Editable` 的 `select` 方法、`Checkbox`、`Radio` 均支持传递闭包。

使用方法如下：

``` php
$grid->created_at('Created at')->radio(function ($row) {
    return [$row->created_at, $row->updated_at];
});
```
传递的闭包「接收参数」为本行数据的数组，「返回值」为真正传递的数据数组。

另外由于使用了闭包类的 `call` 方法调用闭包，所以闭包内的 `$this` 指向当前 `Displayer` 实例，可以使灵活性更高，使用示例如下：

``` php
$allTags = Tag::all()->pluck('name', 'id')->toArray();

$grid->tags('Tags')->checkbox(function () use ($allTags) {
    // $this 指向 Checkbox 实例
    $this->value = array_column($this->value, 'id');
    return $allTags;
});

```

以上代码效果如下图
![_ _20180918205028](https://user-images.githubusercontent.com/23761319/45688652-8c605200-bb84-11e8-8bea-94d1996e5fe2.png)

---

另外本人发现 `Checkbox` 类并没有将 `Arrayable` 类型的 `value` 转为普通数组的过程，这会导致以下代码失败。

``` php
$grid->tags('Tags')->pluck('id')->checkbox(function () {
    return Tag::all()->pluck('name', 'id')->toArray();
});
``` 

出现错误：

![_ _20180918205711](https://user-images.githubusercontent.com/23761319/45689023-73a46c00-bb85-11e8-86f5-693141beae56.png)

所以本人修改了 `Checkbox` 类，增加了对 `Arrayable` 对象转换为普通数组的逻辑。使上述代码能够正常运行。