### PR TITLE
fix #2541 Filter 支持自定义 id

### DIFF
--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -390,7 +390,7 @@ abstract class AbstractFilter
     }
 
     /**
-     * Set element id
+     * Set element id.
      *
      * @param string $id
      *

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -390,6 +390,20 @@ abstract class AbstractFilter
     }
 
     /**
+     * Set element id
+     *
+     * @param string $id
+     *
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $this->formatId($id);
+
+        return $this;
+    }
+
+    /**
      * Get column name of current filter.
      *
      * @return string


### PR DESCRIPTION
解决 issue #2541 

关闭默认 ID 过滤器后自定义新的  ID 过滤器，示例如下：

``` php
$grid->filter(function (Grid\Filter $filter) {
    $filter->disableIdFilter();
    $filter->equal('id', '产品序列号')->setId('product_id');
});
```
---
解析：

不能在调用 `disableIdFilter` 方法后添加「自定义 ID 过滤器」的原因是： `Filter` 类的 `removeIDFilterIfNeeded` 会将所有 `id` 为 `model` 主键名的 `filter` 都移除，又因为 `filter` 的 `id` 只能为 `column` 名而不能自定义。所以「默认 ID 过滤器」和「自定义 ID过滤器」的 `id` 都为 `model` 主键名，统统都会被移除。因此新增了 `setId` 方法，允许用户自定义 `id`。

PS：

本人也思考过能不能实现「存在自定义就用自定义ID过滤器，不存在就用默认ID过滤器」的功能。后面实现这样似乎改动比较大，可能会有不兼容的修改。所以采用这个折中的方法。当然如果有更好的方法，就更好了！