### PR TITLE
fix #2546 修复关联表不支持 switch 的 bug

### DIFF
--- a/src/Grid/Displayers/SwitchDisplay.php
+++ b/src/Grid/Displayers/SwitchDisplay.php
@@ -22,7 +22,7 @@ class SwitchDisplay extends AbstractDisplayer
     {
         $this->updateStates($states);
 
-        $name = $this->column->getName();
+        $name = str_replace('.', '_', $this->column->getName());
 
         $class = "grid-switch-{$name}";
 

--- a/src/Grid/Displayers/SwitchDisplay.php
+++ b/src/Grid/Displayers/SwitchDisplay.php
@@ -22,9 +22,19 @@ class SwitchDisplay extends AbstractDisplayer
     {
         $this->updateStates($states);
 
-        $name = str_replace('.', '_', $this->column->getName());
+        $name = $this->column->getName();
 
-        $class = "grid-switch-{$name}";
+        $class = "grid-switch-" . str_replace('.', '-', $name);
+
+        $keys = collect(explode('.', $name));
+        if ($keys->isEmpty()) {
+            $key = $name;
+        } else {
+            $key = $keys->shift()
+                . $keys->reduce(function ($carry, $val) {
+                    return $carry . "[$val]";}
+                );
+        }
 
         $script = <<<EOT
 
@@ -45,7 +55,7 @@ $('.$class').bootstrapSwitch({
             url: "{$this->grid->resource()}/" + pk,
             type: "POST",
             data: {
-                $name: value,
+                "$key": value,
                 _token: LA.token,
                 _method: 'PUT'
             },

--- a/src/Grid/Displayers/SwitchDisplay.php
+++ b/src/Grid/Displayers/SwitchDisplay.php
@@ -24,16 +24,15 @@ class SwitchDisplay extends AbstractDisplayer
 
         $name = $this->column->getName();
 
-        $class = "grid-switch-" . str_replace('.', '-', $name);
+        $class = 'grid-switch-'.str_replace('.', '-', $name);
 
         $keys = collect(explode('.', $name));
         if ($keys->isEmpty()) {
             $key = $name;
         } else {
-            $key = $keys->shift()
-                . $keys->reduce(function ($carry, $val) {
-                    return $carry . "[$val]";}
-                );
+            $key = $keys->shift().$keys->reduce(function ($carry, $val) {
+                return $carry."[$val]";
+            });
         }
 
         $script = <<<EOT


### PR DESCRIPTION
修复 issue #2546 

产生 BUG 的原因是 `SwitchDisplay` 的 `display` 方法中设置 CSS 类名和发送 AJAX 请求的参数均直接用了 `$this->column->getName()` 方法获取的列名，但在关联表的时候列名为 `关联方法名.字段名` 因为 `.` 号不符合 CSS 语法，导致 `switch` 无法正常使用。~~~直接将列名中的 `.` 替换为 `_` 可解决该问题。~~~
所以将列名的 `.` 替换为 `-`，设置为 CSS 类名。

此外在发送 AJAX 请求时，因为带 `.` 号的参数，会被 PHP 自动转义为 `_`，例如 `order.status` 会变为 `order_status`，导致无法正常更新对应的关联关系的值，但是将其改为 `order[status]` 即可正常更新。

使用 DEMO

``` php
protected function grid()
{
    $grid = new Grid(new Post);
    $states = [
        'on' => ['value' => 'open', 'text' => 'OPEN', 'color' => 'primary'],
        'off' => ['value' => 'close', 'text' => 'CLOSE', 'color' => 'default'],
    ];
    $grid->order()->status('Order Status')->switch($states);
}

protected function form()
{
    $form = new Form(new Post);
    $states = [
        'on' => ['value' => 'open', 'text' => 'OPEN', 'color' => 'primary'],
        'off' => ['value' => 'close', 'text' => 'CLOSE', 'color' => 'default'],
    ];
    $form->switch('order.status', 'Order Status')->states($states);
}
```

