### PR TITLE
Switch Group 支持关联表并完善文档

### DIFF
--- a/docs/zh/model-form-fields.md
+++ b/docs/zh/model-form-fields.md
@@ -552,6 +552,30 @@ $form->html('你的html内容', $label = '');
 $form->tags('keywords');
 ```
 
+`tags`同样支持`ManyToMany`的关系，示例如下：
+
+```php
+$form->tags('tags', '文章标签')
+    ->pluck('name', 'id') // name 为需要显示的 Tag 模型的字段，id 为主键
+    ->options(Tag::all());// 下拉框选项
+```
+
+注意：处理`ManyToMany`关系时必须调用`pluck`方法，指定显示的字段名和主键。
+此外 `options` 方法传入一个`Collection`对象时，`options`会自动调用该对象的`pluck`方法转为`['主键名' => '显示字段名']` 数组，作为下拉框选项。或者可以直接使用`['主键名' => '显示字段名']`这样的数组作为参数。
+
+`tags`还支持`saving`方法用于处理提交的数据，示例如下：
+
+```php
+$form->tags('tags', '文章标签')
+    ->pluck('name', 'id')
+    ->options(Tag::all())
+    ->saving(function ($value) {
+        return $value;
+    });
+```
+
+`saving` 方法接收一个「参数为 tags 的提交值，返回值为修改后的 tags 提交值」的闭包，可以用于实现自动创建新 tag 或其它功能。
+
 ## 图标
 选择`font-awesome`图标
 ```php

--- a/docs/zh/model-grid-column.md
+++ b/docs/zh/model-grid-column.md
@@ -39,6 +39,14 @@ $grid->title()->editable('textarea');
 
 $grid->title()->editable('select', [1 => 'option1', 2 => 'option2', 3 => 'option3']);
 
+// select 支持传递闭包作为参数，该闭包接收参数为当前行对应的模型
+$grid->title()->editable('select', function($row) {
+    if ($row->title === 'test') {
+        return ['test1', 'test2'];
+    }
+    return ['test3', 'test4'];
+});
+
 $grid->birth()->editable('date');
 
 $grid->published_at()->editable('datetime');
@@ -80,9 +88,10 @@ $states = [
 ];
 
 $grid->column('switch_group')->switchGroup([
-    'hot'       => '热门',
-    'new'       => '最新'
-    'recommend' => '推荐',
+    'hot'        => '热门',
+    'new'        => '最新',
+    'recommend'  => '推荐',
+    'image.show' => '显示图片', // 更新对应关联模型
 ], $states);
 
 ```
@@ -98,6 +107,8 @@ $grid->options()->select([
 ]);
 ```
 
+`select` 也支持参数为闭包，使用方法和`editable`的`select`类似。
+
 ### radio
 ```php
 $grid->options()->radio([
@@ -108,6 +119,8 @@ $grid->options()->radio([
 ]);
 ```
 
+`radio` 也支持参数为闭包，使用方法和`editable`的`select`类似。
+
 ### checkbox
 ```php
 $grid->options()->checkbox([
@@ -117,6 +130,8 @@ $grid->options()->checkbox([
     4 => 'laudantium, totam rem aperiam',
 ]);
 ```
+
+`checkbox` 也支持参数为闭包，使用方法和`editable`的`select`类似。
 
 ### image
 

--- a/docs/zh/model-grid-filters.md
+++ b/docs/zh/model-grid-filters.md
@@ -7,6 +7,10 @@ $grid->filter(function($filter){
 
     // 去掉默认的id过滤器
     $filter->disableIdFilter();
+    
+    // 自定义id过滤器，在去掉默认id过滤器后必须调用 setId 方法，
+    // 并设置一个和主键不同的值，自定义的id过滤器才会显示。
+    $filter->equal('id', '产品序列号')->setId('product_id');
 
     // 在这里添加字段过滤器
     $filter->like('name', 'name');

--- a/src/Grid/Displayers/SwitchGroup.php
+++ b/src/Grid/Displayers/SwitchGroup.php
@@ -40,7 +40,16 @@ class SwitchGroup extends AbstractDisplayer
 
     protected function buildSwitch($name, $label = '')
     {
-        $class = "grid-switch-{$name}";
+        $class = 'grid-switch-'.str_replace('.', '-', $name);
+
+        $keys = collect(explode('.', $name));
+        if ($keys->isEmpty()) {
+            $key = $name;
+        } else {
+            $key = $keys->shift().$keys->reduce(function ($carry, $val) {
+                return $carry."[$val]";
+            });
+        }
 
         $script = <<<EOT
 
@@ -58,7 +67,7 @@ $('.$class').bootstrapSwitch({
             url: "{$this->grid->resource()}/" + pk,
             type: "POST",
             data: {
-                $name: value,
+                "$key": value,
                 _token: LA.token,
                 _method: 'PUT'
             },


### PR DESCRIPTION
哈哈，又马大哈了，之前修复了 `Switch`的问题（#2548）却忘记修复 `Switch Group`。这个 PR 用同样的方法修复了这个问题。另外更新了一下文档，不过本人文笔不好，如果描述不清或有误请指正。