### PR TITLE
Shows empty file download section

### DIFF
--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -232,6 +232,7 @@ class Field implements Renderable
      */
     public function file($server = '', $download = true)
     {
+        if ( ! $this->value ) return;
         $field = $this;
 
         return $this->unescape()->as(function ($path) use ($server, $download, $field) {


### PR DESCRIPTION
`$show->dosya('Dosya')->file();`

I used dosya field as `file`, column is null but in show, showing empty download section

![image](https://user-images.githubusercontent.com/8195419/46795235-54e36080-cd52-11e8-9d7c-a5d7866e3324.png)