### PR TITLE
modelTree::selectOptions增加过滤功能

### DIFF
--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -229,13 +229,15 @@ trait ModelTree
     /**
      * Get options for Select field in form.
      *
-     * @return \Illuminate\Support\Collection
+     * @param \Closure|null $closure
+     * @param string        $rootText
+     * @return array
      */
-    public static function selectOptions()
+    public static function selectOptions(\Closure $closure = null, $rootText = 'Root')
     {
-        $options = (new static())->buildSelectOptions();
+        $options = (new static())->withQuery($closure)->buildSelectOptions();
 
-        return collect($options)->prepend('Root', 0)->all();
+        return collect($options)->prepend($rootText, 0)->all();
     }
 
     /**

--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -231,6 +231,7 @@ trait ModelTree
      *
      * @param \Closure|null $closure
      * @param string        $rootText
+     *
      * @return array
      */
     public static function selectOptions(\Closure $closure = null, $rootText = 'Root')

--- a/tests/ModelTreeTest.php
+++ b/tests/ModelTreeTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Encore\Admin\Auth\Database\Administrator;
-use Encore\Admin\Auth\Database\Menu;
 use Tests\Models\Tree;
 
 class ModelTreeTest extends TestCase

--- a/tests/ModelTreeTest.php
+++ b/tests/ModelTreeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Encore\Admin\Auth\Database\Administrator;
+use Encore\Admin\Auth\Database\Menu;
+use Tests\Models\Tree;
+
+class ModelTreeTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testSelectOptions()
+    {
+        $rootText = 'Root Text';
+
+        $options = Tree::selectOptions(function ($query) {
+            return $query->where('uri', '');
+        }, $rootText);
+
+        $count = Tree::query()->where('uri', '')->count();
+
+        $this->assertEquals(array_shift($options), $rootText);
+        $this->assertEquals(count($options), $count);
+    }
+}

--- a/tests/models/Tree.php
+++ b/tests/models/Tree.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Models;
+
+use Encore\Admin\Traits\AdminBuilder;
+use Encore\Admin\Traits\ModelTree;
+use Illuminate\Database\Eloquent\Model;
+
+class Tree extends Model
+{
+    use AdminBuilder, ModelTree;
+
+    /**
+     * Create a new Eloquent model instance.
+     *
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $connection = config('admin.database.connection') ?: config('database.default');
+
+        $this->setConnection($connection);
+
+        $this->setTable(config('admin.database.menu_table'));
+
+        parent::__construct($attributes);
+    }
+}


### PR DESCRIPTION
使用场景：
如我使用 ModelTree 构建一个文件系统，展示的时候是没有问题的，但是当我新建文件/文件夹的时候，我希望能选择的父级是只能是 type=文件夹的，并增加了可以修改根级别显示的文字，这不会影响到原来的代码。