### PR TITLE
Field::formatName() 判断失败, 导致此函数无限循环.

### DIFF
--- a/src/Form/Field/Map.php
+++ b/src/Form/Field/Map.php
@@ -39,8 +39,8 @@ class Map extends Field
 
     public function __construct($column, $arguments)
     {
-        $this->column['lat'] = $column;
-        $this->column['lng'] = $arguments[0];
+        $this->column['lat'] = (string) $column;
+        $this->column['lng'] = (string) $arguments[0];
 
         array_shift($arguments);
 


### PR DESCRIPTION
如果使用数字当参数 ```new Map(45, 116)```, 则会在Field::formatName()的第一个判断 if (is_string($column)) { 处判断失败, 会导致 Field::formatName() 无限循环.