### PR TITLE
[fix] Skipped paginate method when some filters already #2384

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -364,9 +364,10 @@ class Model
         $this->setSort();
         $this->setPaginate();
 
-        $this->queries->unique()->each(function ($query) {
-            $this->model = call_user_func_array([$this->model, $query['method']], $query['arguments']);
-        });
+        foreach ($this->queries->unique()->toArray() as $query) {
+            $tmp_model = call_user_func_array([$this->model, $query['method']], $query['arguments']);
+        }
+        $this->model = $tmp_model;
 
         if ($this->model instanceof Collection) {
             return $this->model;


### PR DESCRIPTION
有筛选条件时，自定义的paginate方法不走了，这样自定义的数据库源，或者外部数据源都无法利用现有的filter传递过滤参数了。
因为中间$this->model不指向自定义的模型了，其实在这个循环中，改变$this->model没什么用，不改变$this->model，也是可以调用laravel的模型方法的，因为自定义模型已经继承了，只在最后改变就行了。