### PR TITLE
Don't show if file is empty

### DIFF
--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -253,6 +253,8 @@ class Field implements Renderable
                 }
             }
 
+            if (!$url) return '';
+            
             return <<<HTML
 <ul class="mailbox-attachments clearfix">
     <li style="margin-bottom: 0;">


### PR DESCRIPTION
I used file field on form. But this isn't required so when no file selected.. Show empty file dialog.
Now will not appear.

![image](https://user-images.githubusercontent.com/8195419/47839009-23ded480-ddc2-11e8-8362-89e0567baa59.png)
