### PR TITLE
[fix]#2743 Call custom `with` when overwrite, otherwise the default.

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -1070,7 +1070,7 @@ class Form implements Renderable
     {
         $relations = $this->getRelations();
 
-        $builder = $this->model()->newQuery();
+        $builder = $this->model();
 
         if ($this->isSoftDeletes) {
             $builder->withTrashed();


### PR DESCRIPTION
有`newQuery`的话，一开始`$builder`就是`Illuminate\Database\Eloquent\Builder`，就算在模型里重写了`public static function with`也不被调用，应该把这个去掉，这样当用户定义`with`时，调用自定义的，没有定义时，调用默认的。