### PR TITLE
修复filter的级联select框在多次搜索时 pjax 重复绑定change事件

### DIFF
--- a/src/Grid/Filter/Presenter/Select.php
+++ b/src/Grid/Filter/Presenter/Select.php
@@ -268,7 +268,7 @@ EOT;
         $column = $this->filter->getColumn();
 
         $script = <<<EOT
-
+$(document).off('change', ".{$this->getClass($column)}");
 $(document).on('change', ".{$this->getClass($column)}", function () {
     var target = $(this).closest('form').find(".{$this->getClass($target)}");
     $.get("$resourceUrl?q="+this.value, function (data) {


### PR DESCRIPTION
在filter有级联select框存在时 , 会导致多次搜索过后多次请求级联API , 应增加取消绑定change事件的代码