### PR TITLE
supported bootstrap grid prefix in Layout/Column, 

### DIFF
--- a/src/Layout/Column.php
+++ b/src/Layout/Column.php
@@ -9,7 +9,7 @@ class Column implements Buildable
 {
     /**
      * grid system prefix width
-     * 
+     *
      * @var array
      */
     protected $width = [];

--- a/src/Layout/Column.php
+++ b/src/Layout/Column.php
@@ -8,9 +8,11 @@ use Illuminate\Contracts\Support\Renderable;
 class Column implements Buildable
 {
     /**
-     * @var int
+     * grid system prefix width
+     * 
+     * @var array
      */
-    protected $width = 12;
+    protected $width = [];
 
     /**
      * @var array
@@ -31,7 +33,17 @@ class Column implements Buildable
             $this->append($content);
         }
 
-        $this->width = $width;
+        ///// set width.
+        // if null, or $this->width is empty array, set as "md" => "12"
+        if (is_null($width) || (is_array($width) && count($width) === 0)) {
+            $this->width['md'] = 12;
+        }
+        // $this->width is number(old version), set as "md" => $width
+        elseif (is_numeric($width)) {
+            $this->width['md'] = $width;
+        } else {
+            $this->width = $width;
+        }
     }
 
     /**
@@ -99,7 +111,11 @@ class Column implements Buildable
      */
     protected function startColumn()
     {
-        echo "<div class=\"col-md-{$this->width}\">";
+        // get classname using width array
+        $classname = implode(' ', collect($this->width)->map(function ($value, $key) {
+            return "col-$key-$value";
+        })->toArray());
+        echo "<div class=\"{$classname}\">";
     }
 
     /**


### PR DESCRIPTION
ex. col-sm-6 col-lg…12 col-xs-3

How to use
~~~
///// current writing
$content->row(function(Row $row) {
    $row->column(4, 'foo');
    $row->column(4, 'bar');
    $row->column(4, 'baz');
});
// output <div class="row"><div class="col-md-4">foo</div><div class="col-md-4">bar</div><div class="col-md-4">baz</div></div>

///// supported array
$content->row(function(Row $row) {
    $row->column(['md' => 4, 'sm' => 6, 'xs' => 12], 'foo');
    $row->column(['md' => 4, 'sm' => 6, 'xs' => 12], 'bar');
    $row->column(['md' => 4, 'sm' => 6, 'xs' => 12], 'baz');
});
// output <div class="row"><div class="col-md-4 col-sm-6 col-xs-12">foo</div><div class="col-md-4 col-sm-6 col-xs-12">bar</div><div class="col-md-4 col-sm-6 col-xs-12">baz</div></div>
~~~

*I have error StyleCI, So I updated source code