### PR TITLE
Added an option to custom the controller stub

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -46,6 +46,7 @@ class MakeCommand extends GeneratorCommand
 
         if ($stub and !is_file($stub)) {
             $this->error("The stub file dose not exist.");
+
             return false;
         }
 

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -44,7 +44,7 @@ class MakeCommand extends GeneratorCommand
 
         $stub = $this->option('stub');
 
-        if ($stub and ! is_file($stub)) {
+        if ($stub and !is_file($stub)) {
             $this->error("The stub file dose not exist.");
             return false;
         }

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -12,7 +12,10 @@ class MakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'admin:make {name} {--model=} {--O|output}';
+    protected $signature = 'admin:make {name} 
+        {--model=} 
+        {--stub= : Path to the custom stub file. } 
+        {--O|output}';
 
     /**
      * The console command description.
@@ -36,6 +39,13 @@ class MakeCommand extends GeneratorCommand
         if (!$this->modelExists()) {
             $this->error('Model does not exists !');
 
+            return false;
+        }
+
+        $stub = $this->option('stub');
+
+        if ($stub and ! is_file($stub)) {
+            $this->error("The stub file dose not exist.");
             return false;
         }
 
@@ -128,6 +138,10 @@ class MakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($stub = $this->option('stub')) {
+            return $stub;
+        }
+
         if ($this->option('model')) {
             return __DIR__.'/stubs/controller.stub';
         }

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -45,7 +45,7 @@ class MakeCommand extends GeneratorCommand
         $stub = $this->option('stub');
 
         if ($stub and !is_file($stub)) {
-            $this->error("The stub file dose not exist.");
+            $this->error('The stub file dose not exist.');
 
             return false;
         }


### PR DESCRIPTION
Write your own controller stub file (eg. /path/to/my.stubs)  based on https://github.com/z-song/laravel-admin/blob/master/src/Console/stubs/controller.stub
Then specify your stub file when making controllers:
```sh
php artisan admin:make --model=MyModel --stub=/path/to/my.stubs MyController
```