### PR TITLE
修复在Form中，给字段设置空值无效

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -1551,7 +1551,7 @@ class Form implements Renderable
      */
     public function __set($name, $value)
     {
-        $this->input($name, $value);
+        return array_set($this->inputs, $name, $value);
     }
 
     /**


### PR DESCRIPTION
#2814 

修复在Form中，给字段设置空值无效