### PR TITLE
修正当 admin.route.prefix 为空的时候权限列表的路由那里显示两个 / 的bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 *.project
 .idea/
 .php_cs.cache
+.vscode/

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -105,7 +105,7 @@ class PermissionController extends Controller
                     return "<span class='label label-primary'>{$name}</span>";
                 })->implode('&nbsp;');
                 
-                if(!empty(config('admin.route.prefix'))) {
+                if (!empty(config('admin.route.prefix'))) {
                     $path = '/'.trim(config('admin.route.prefix'), '/').$path;
                 }
 
@@ -157,7 +157,7 @@ class PermissionController extends Controller
                     return "<span class='label label-primary'>{$name}</span>";
                 })->implode('&nbsp;');
 
-                if(!empty(config('admin.route.prefix'))) {
+                if (!empty(config('admin.route.prefix'))) {
                     $path = '/'.trim(config('admin.route.prefix'), '/').$path;
                 }
 

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -156,7 +156,6 @@ class PermissionController extends Controller
                 })->map(function ($name) {
                     return "<span class='label label-primary'>{$name}</span>";
                 })->implode('&nbsp;');
-
                 if (!empty(config('admin.route.prefix'))) {
                     $path = '/'.trim(config('admin.route.prefix'), '/').$path;
                 }

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -104,8 +104,10 @@ class PermissionController extends Controller
                 })->map(function ($name) {
                     return "<span class='label label-primary'>{$name}</span>";
                 })->implode('&nbsp;');
-
-                $path = '/'.trim(config('admin.route.prefix'), '/').$path;
+                
+                if(!empty(config('admin.route.prefix'))) {
+                    $path = '/'.trim(config('admin.route.prefix'), '/').$path;
+                }
 
                 return "<div style='margin-bottom: 5px;'>$method<code>$path</code></div>";
             })->implode('');
@@ -155,7 +157,9 @@ class PermissionController extends Controller
                     return "<span class='label label-primary'>{$name}</span>";
                 })->implode('&nbsp;');
 
-                $path = '/'.trim(config('admin.route.prefix'), '/').$path;
+                if(!empty(config('admin.route.prefix'))) {
+                    $path = '/'.trim(config('admin.route.prefix'), '/').$path;
+                }
 
                 return "<div style='margin-bottom: 5px;'>$method<code>$path</code></div>";
             })->implode('');


### PR DESCRIPTION
当直接用域名作为入口时类似这样 http://www.admin.com
把 admin.route.prefix 配置为空字符，但是这样在权限列表里面的权限列表所有路由前面都显示两个 //
例如：
//auth/login
这个对有洁癖的人很有疗效，看着不舒服