### PR TITLE
Layout-only filter for more custom search.

### DIFF
--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -103,6 +103,20 @@ class Filter implements Renderable
     protected $layout;
 
     /**
+     * Set this filter only in the layout.
+     *
+     * @var bool
+     */
+    protected $thisFilterLayoutOnly = false;
+
+    /**
+     * Columns of filter that are layout-only.
+     *
+     * @var array
+     */
+    protected $layoutOnlyFilterColumns = [];
+
+    /**
      * Primary key of giving model.
      *
      * @var mixed
@@ -280,7 +294,11 @@ class Filter implements Renderable
         $this->removeIDFilterIfNeeded();
 
         foreach ($this->filters() as $filter) {
-            $conditions[] = $filter->condition($params);
+            if (in_array($column = $filter->getColumn(), $this->layoutOnlyFilterColumns)) {
+                $filter->default(array_get($params, $column));
+            } else {
+                $conditions[] = $filter->condition($params);
+            }
         }
 
         return tap(array_filter($conditions), function ($conditions) {
@@ -311,6 +329,18 @@ class Filter implements Renderable
     }
 
     /**
+     * Set this filter layout only.
+     *
+     * @return $this
+     */
+    public function layoutOnly()
+    {
+        $this->thisFilterLayoutOnly = true;
+
+        return $this;
+    }
+
+    /**
      * Add a filter to grid.
      *
      * @param AbstractFilter $filter
@@ -322,6 +352,11 @@ class Filter implements Renderable
         $this->layout->addFilter($filter);
 
         $filter->setParent($this);
+
+        if ($this->thisFilterLayoutOnly) {
+            $this->thisFilterLayoutOnly = false;
+            $this->layoutOnlyFilterColumns[] = $filter->getColumn();
+        }
 
         return $this->filters[] = $filter;
     }


### PR DESCRIPTION
满足更自定义化的filter，column可以不在表中
示例如下：
默认显示age>10的数据
```php
$grid->model()
    ->when(!request('show_all'), function ($query) {
        return $query->where('age', '>', 10);
    });
```
选择后显示全部数据
```php
$grid->filter(function ($filter) {
    $filter->layoutOnly()->equal('show_all', ' ')->checkbox([1 => '查看全部'])->default('');
});
```
