### PR TITLE
权限控制如果是 ajax 请求时，没有权限返回 403 Forbidden 状态

### DIFF
--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -87,6 +87,10 @@ class Permission
     {
         $response = response(Admin::content()->withError(trans('admin.deny')));
 
+        if (request()->ajax()) {
+            abort(403, trans('admin.deny'));
+        }
+        
         Pjax::respond($response);
     }
 

--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -87,7 +87,7 @@ class Permission
     {
         $response = response(Admin::content()->withError(trans('admin.deny')));
 
-        if (request()->ajax()) {
+        if (!request()->pjax() && request()->ajax()) {
             abort(403, trans('admin.deny'));
         }
 

--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -90,7 +90,7 @@ class Permission
         if (request()->ajax()) {
             abort(403, trans('admin.deny'));
         }
-        
+
         Pjax::respond($response);
     }
 


### PR DESCRIPTION
目前权限控制，如果 ajax 请求还是返回整个页面，前端 js 无法很好地做相应的处理。
因此调整为如果是 ajax 请求没有权限就返回 403 状态，前端根据状态码做处理