### PR TITLE
$form->image();时不选择图片会报错修复

### DIFF
--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -101,6 +101,10 @@ class File extends Field
      */
     public function prepare($file)
     {
+        if (empty($file)) {
+            return null;
+        }
+        
         if (request()->has(static::FILE_DELETE_FLAG)) {
             return $this->destroy();
         }


### PR DESCRIPTION
修复使用$form->image();时不选择图片会报错情况