### PR TITLE
Fix an issue where some fields are invalid when they are empty

### DIFF
--- a/src/Layout/Content.php
+++ b/src/Layout/Content.php
@@ -12,14 +12,14 @@ class Content implements Renderable
      *
      * @var string
      */
-    protected $header = '';
+    protected $header = ' ';
 
     /**
      * Content description.
      *
      * @var string
      */
-    protected $description = '';
+    protected $description = ' ';
 
     /**
      * Page breadcrumb.


### PR DESCRIPTION
修复设置某个字段为空时失效的问题，比如
![image](https://user-images.githubusercontent.com/25813184/50826883-e5443800-1377-11e9-9c45-ca37ef018d8f.png)这种情况页面显示默认值，
![image](https://user-images.githubusercontent.com/25813184/50826923-fdb45280-1377-11e9-922d-41b7d2fdb4ce.png)
无法删除。必须中间加空格解决
 ->description('  ')添加了空格

