### PR TITLE
modify admin_base_path if $path is null, "" or "/"

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -53,7 +53,13 @@ if (!function_exists('admin_base_path')) {
 
         $prefix = ($prefix == '/') ? '' : $prefix;
 
-        return $prefix.'/'.trim($path, '/');
+        $path = trim($path, '/');
+
+        if (is_null($path) || strlen($path) == 0) {
+            return $prefix;
+        }
+
+        return $prefix.'/'.$path;
     }
 }
 


### PR DESCRIPTION
If $path is null, "" or "/", return "/admin/" before this commit.
But Laravel default ".htaccess" setting redirects url "/admin/" to "/admin".

So I modified returning "/admin" if $path is null, "" or "/".