### PR TITLE
important bug in permission

### DIFF
--- a/src/Middleware/Permission.php
+++ b/src/Middleware/Permission.php
@@ -25,7 +25,7 @@ class Permission
      */
     public function handle(Request $request, \Closure $next, ...$args)
     {
-        if (!Admin::user() || !empty($args)) {
+        if (!Admin::user() || empty($args)) {
             return $next($request);
         }
 


### PR DESCRIPTION
I think this 
 if (!Admin::user() || !empty($args)) {
should be this
 if (!Admin::user() || empty($args)) {