### PR TITLE
修复 image 类型使用 macro 失败

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -1051,6 +1051,18 @@ class Field implements Renderable
     {
         return $this->script;
     }
+    
+    /**
+     * To set this field should render or not.
+     *
+     * @return self
+     */
+    public function setDisplay(bool $display)
+    {
+        $this->display = $display;
+        
+        return $this;
+    }
 
     /**
      * If this field should render.

--- a/src/Form/Field/ImageField.php
+++ b/src/Form/Field/ImageField.php
@@ -58,6 +58,10 @@ trait ImageField
      */
     public function __call($method, $arguments)
     {
+        if (static::hasMacro($method)) {
+            return $this;
+        }
+        
         if (!class_exists(ImageManagerStatic::class)) {
             throw new \Exception('To use image handling and manipulation, please install [intervention/image] first.');
         }


### PR DESCRIPTION
使用 Filed::macro() 时候，当 Filed 类使用了 ImageField ，会先检测 ImageManagerStatic ，导致 macro 失败，改为先检测 macro 即可解决