### PR TITLE
Table view for HasMany field

### DIFF
--- a/resources/assets/laravel-admin/laravel-admin.css
+++ b/resources/assets/laravel-admin/laravel-admin.css
@@ -39,3 +39,24 @@ a.editable-empty {
 .mailbox-attachments li {
     width: 300px !important;
 }
+
+.table-has-many .form-group {
+    margin-bottom: 0 !important;
+}
+
+
+.table-has-many label.control-label[for=inputError] {
+    position: absolute;
+    z-index: 100;
+    background-color: #fff;
+    border: 1px solid #dd4b39;
+    border-radius: 5px;
+    text-align: left;
+    top: 34px;
+    padding: 8px;
+    line-height: 1.2;
+}
+
+.table-has-many label.control-label[for=inputError]+br {
+    display: none;
+}

--- a/resources/views/form/hasmanytable.blade.php
+++ b/resources/views/form/hasmanytable.blade.php
@@ -1,0 +1,75 @@
+
+<div class="row">
+    <div class="{{$viewClass['label']}}"><h4 class="pull-right">{{ $label }}</h4></div>
+    <div class="{{$viewClass['field']}}">
+        <div id="has-many-{{$column}}" style="margin-top: 15px;">
+            <table class="table table-has-many has-many-{{$column}}">
+                <thead>
+                <tr>
+                    @foreach($headers as $header)
+                        <th>{{ $header }}</th>
+                    @endforeach
+
+                    <th class="hidden"></th>
+
+                    @if($options['allowDelete'])
+                        <th></th>
+                    @endif
+                </tr>
+                </thead>
+                <tbody class="has-many-{{$column}}-forms">
+                @foreach($forms as $pk => $form)
+                    <tr class="has-many-{{$column}}-form fields-group">
+
+                        <?php $hidden = ''; ?>
+
+                        @foreach($form->fields() as $field)
+
+                            @if (is_a($field, \Encore\Admin\Form\Field\Hidden::class))
+                                <?php $hidden .= $field->render(); ?>
+                                @continue
+                            @endif
+
+                            <td>{!! $field->setLabelClass(['hidden'])->setWidth(12, 0)->render() !!}</td>
+                        @endforeach
+
+                        <td class="hidden">{!! $hidden !!}</td>
+
+                        @if($options['allowDelete'])
+                            <td class="form-group">
+                                <div>
+                                    <div class="remove btn btn-warning btn-sm pull-right"><i class="fa fa-trash">&nbsp;</i>{{ trans('admin.remove') }}</div>
+                                </div>
+                            </td>
+                        @endif
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+
+            <template class="{{$column}}-tpl">
+                <tr class="has-many-{{$column}}-form fields-group">
+
+                    {!! $template !!}
+
+                    <td class="form-group">
+                        <div>
+                            <div class="remove btn btn-warning btn-sm pull-right"><i class="fa fa-trash">&nbsp;</i>{{ trans('admin.remove') }}</div>
+                        </div>
+                    </td>
+                </tr>
+            </template>
+
+            @if($options['allowCreate'])
+                <div class="form-group">
+                    <div class="{{$viewClass['field']}}">
+                        <div class="add btn btn-success btn-sm"><i class="fa fa-save"></i>&nbsp;{{ trans('admin.new') }}</div>
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+</div>
+
+<hr style="margin-top: 0px;">
+

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -54,6 +54,7 @@ class HasMany extends Field
     protected $views = [
         'default' => 'admin::form.hasmany',
         'tab'     => 'admin::form.hasmanytab',
+        'table'   => 'admin::form.hasmanytable',
     ];
 
     /**
@@ -336,6 +337,16 @@ class HasMany extends Field
     {
         return $this->mode('tab');
     }
+    
+    /**
+     * Use table mode to showing hasmany field.
+     *
+     * @return HasMany
+     */
+    public function useTable()
+    {
+        return $this->mode('table');
+    }
 
     /**
      * Build Nested form for related data.
@@ -498,6 +509,48 @@ EOT;
 
         Admin::script($script);
     }
+    
+    /**
+     * Setup default template script.
+     *
+     * @param string $templateScript
+     *
+     * @return void
+     */
+    protected function setupScriptForTableView($templateScript)
+    {
+        $removeClass = NestedForm::REMOVE_FLAG_CLASS;
+        $defaultKey = NestedForm::DEFAULT_KEY_NAME;
+        
+        /**
+         * When add a new sub form, replace all element key in new sub form.
+         *
+         * @example comments[new___key__][title]  => comments[new_{index}][title]
+         *
+         * {count} is increment number of current sub form count.
+         */
+        $script = <<<EOT
+var index = 0;
+$('#has-many-{$this->column}').on('click', '.add', function () {
+
+    var tpl = $('template.{$this->column}-tpl');
+
+    index++;
+
+    var template = tpl.html().replace(/{$defaultKey}/g, index);
+    $('.has-many-{$this->column}-forms').append(template);
+    {$templateScript}
+});
+
+$('#has-many-{$this->column}').on('click', '.remove', function () {
+    $(this).closest('.has-many-{$this->column}-form').hide();
+    $(this).closest('.has-many-{$this->column}-form').find('.$removeClass').val(1);
+});
+
+EOT;
+        
+        Admin::script($script);
+    }
 
     /**
      * Disable create button.
@@ -532,6 +585,10 @@ EOT;
      */
     public function render()
     {
+        if ($this->viewMode == 'table') {
+            return $this->renderTable();
+        }
+
         // specify a view to render.
         $this->view = $this->views[$this->viewMode];
 
@@ -541,6 +598,63 @@ EOT;
         $this->setupScript($script);
 
         return parent::render()->with([
+            'forms'        => $this->buildRelatedForms(),
+            'template'     => $template,
+            'relationName' => $this->relationName,
+            'options'      => $this->options,
+        ]);
+    }
+
+    /**
+     * Render the `HasMany` field for table style
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    protected function renderTable()
+    {
+        $headers = [];
+        $fields = [];
+        $hidden = [];
+        $scripts = [];
+
+        /* @var Field $field */
+        foreach ($this->buildNestedForm($this->column, $this->builder)->fields() as $field) {
+
+            if (is_a($field, Hidden::class)) {
+                $hidden[] = $field->render();
+            } else {
+                /* Hide label and set field width 100% */
+                $field->setLabelClass(['hidden']);
+                $field->setWidth(12, 0);
+                $fields[] = $field->render();
+                $headers[] = $field->label();
+            }
+
+            /*
+             * Get and remove the last script of Admin::$script stack.
+             */
+            if ($field->getScript()) {
+                $scripts[] = array_pop(Admin::$script);
+            }
+        }
+
+        /* Build row elements */
+        $template = array_reduce($fields, function ($all, $field) {
+            $all .= "<td>{$field}</td>";
+            return $all;
+        }, '');
+
+        /* Build cell with hidden elements */
+        $template .= '<td class="hidden">' . implode('', $hidden) . '</td>';
+
+        $this->setupScript(implode("\r\n", $scripts));
+
+        // specify a view to render.
+        $this->view = $this->views[$this->viewMode];
+
+        return parent::render()->with([
+            'headers'      => $headers,
             'forms'        => $this->buildRelatedForms(),
             'template'     => $template,
             'relationName' => $this->relationName,


### PR DESCRIPTION
It is often more convenient to display some relations as a table. This commit adds support for outputting the hasMany form field as a table.

Example

$form->hasMany('keywords', 'Add more keywords', function ($nestedForm) {
	$nestedForm->select('campaign_id', 'Campaign')->options(...);
	$nestedForm->text('title', 'Title');
	$nestedForm->checkbox('active', 'Active keyword');
	...
})->useTable();

Real implementation looks like http://joxi.ru/bmovx88h3yeXZr

Css rules for correct output added to laravel-admin.css (some padding fix + validation error label)