### PR TITLE
Command for export current state of admin tables as a seed

### DIFF
--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -21,6 +21,7 @@ class AdminServiceProvider extends ServiceProvider
         Console\CreateUserCommand::class,
         Console\ResetPasswordCommand::class,
         Console\ExtendCommand::class,
+        Console\ExportSeedCommand::class,
     ];
 
     /**

--- a/src/Console/ExportSeedCommand.php
+++ b/src/Console/ExportSeedCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Encore\Admin\Console;
+
+use Encore\Admin\Admin;
+use Illuminate\Console\Command;
+
+class ExportSeedCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'admin:export-seed {classname=AdminTablesSeeder}
+                                              {--users : add to seed users tables}';
+    
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Export seed a Laravel-admin database tables menu, roles and permissions';
+    
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $name = $this->argument('classname');
+        $exceptFields = [];
+        $exportUsers = $this->option('users');
+        
+        $seedFile = $this->laravel->databasePath() . '/seeds/' . $name . '.php';
+        $contents = $this->getStub('AdminTablesSeeder');
+        
+        $replaces = [
+            'DummyClass' => $name,
+            
+            'ClassMenu'       => config('admin.database.menu_model'),
+            'ClassPermission' => config('admin.database.permissions_model'),
+            'ClassRole'       => config('admin.database.roles_model'),
+            
+            'TableRoleMenu'        => config('admin.database.role_menu_table'),
+            'TableRolePermissions' => config('admin.database.role_permissions_table'),
+            
+            'ArrayMenu'       => $this->getTableDataArrayAsString(config('admin.database.menu_table'), $exceptFields),
+            'ArrayPermission' => $this->getTableDataArrayAsString(config('admin.database.permissions_table'), $exceptFields),
+            'ArrayRole'       => $this->getTableDataArrayAsString(config('admin.database.roles_table'), $exceptFields),
+            
+            'ArrayPivotRoleMenu'        => $this->getTableDataArrayAsString(config('admin.database.role_menu_table'), $exceptFields),
+            'ArrayPivotRolePermissions' => $this->getTableDataArrayAsString(config('admin.database.role_permissions_table'), $exceptFields),
+        ];
+        
+        if ($exportUsers) {
+            $replaces  = array_merge($replaces, [
+                'ClassUsers'            => config('admin.database.users_model'),
+                'TableRoleUsers'        => config('admin.database.role_users_table'),
+                'TablePermissionsUsers' => config('admin.database.user_permissions_table'),
+    
+                'ArrayUsers'                 => $this->getTableDataArrayAsString(config('admin.database.users_table'), $exceptFields),
+                'ArrayPivotRoleUsers'        => $this->getTableDataArrayAsString(config('admin.database.role_users_table'), $exceptFields),
+                'ArrayPivotPermissionsUsers' => $this->getTableDataArrayAsString(config('admin.database.user_permissions_table'), $exceptFields),
+            ]);
+            
+        } else {
+            $contents = preg_replace('/\/\/ users tables[\s\S]*?(?=\/\/ finish)/mu', '', $contents);
+        }
+    
+        $contents = str_replace(array_keys($replaces), array_values($replaces), $contents);
+        
+        $this->laravel['files']->put($seedFile, $contents);
+        
+        $this->line('<info>Admin tables seed file was created:</info> ' . str_replace(base_path(), '', $seedFile));
+        $this->line("Use: <info>php artisan db:seed --class={$name}</info>");
+    }
+    
+    /**
+     * Get data array from table as string result var_export
+     *
+     * @param string $table
+     * @param array $exceptFields
+     * @return string
+     */
+    protected function getTableDataArrayAsString($table, $exceptFields = [])
+    {
+        $fields = \DB::getSchemaBuilder()->getColumnListing($table);
+        $fields = array_diff($fields, $exceptFields);
+        
+        $array = \DB::table($table)->get($fields)->map(function ($item) {
+            return (array)$item;
+        })->all();
+        
+        $string = var_export($array, true);
+        
+        // some pretty view
+        return str_replace(["\n  ", "\n)"], ["\n" . str_repeat(' ', 16), "\n" . str_repeat(' ', 12) . ')'], $string);
+    }
+    
+    /**
+     * Get stub contents.
+     *
+     * @param $name
+     *
+     * @return string
+     */
+    protected function getStub($name)
+    {
+        return $this->laravel['files']->get(__DIR__ . "/stubs/$name.stub");
+    }
+}

--- a/src/Console/stubs/AdminTablesSeeder.stub
+++ b/src/Console/stubs/AdminTablesSeeder.stub
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class DummyClass extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // base tables
+        ClassMenu::truncate();
+        ClassMenu::insert(
+            ArrayMenu
+        );
+
+        ClassPermission::truncate();
+        ClassPermission::insert(
+            ArrayPermission
+        );
+
+        ClassRole::truncate();
+        ClassRole::insert(
+            ArrayRole
+        );
+
+        // pivot tables
+        DB::table('TableRoleMenu')->truncate();
+        DB::table('TableRoleMenu')->insert(
+            ArrayPivotRoleMenu
+        );
+
+        DB::table('TableRolePermissions')->truncate();
+        DB::table('TableRolePermissions')->insert(
+            ArrayPivotRolePermissions
+        );
+
+        // users tables
+        ClassUsers::truncate();
+        ClassUsers::insert(
+            ArrayUsers
+        );
+
+        DB::table('TableRoleUsers')->truncate();
+        DB::table('TableRoleUsers')->insert(
+            ArrayPivotRoleUsers
+        );
+
+        DB::table('TablePermissionsUsers')->truncate();
+        DB::table('TablePermissionsUsers')->insert(
+            ArrayPivotPermissionsUsers
+        );
+
+        // finish
+    }
+}


### PR DESCRIPTION
After the initialization of the laravel-admin, any changes to menu items, roles, permissions are saved in the local database and their transfer (from dev to prod, or to other develeper) is a problem. It is also ideologically correct to keep all the basic elements of the admin panel under the git project.

This commit adds a command

`php artisan admin:export-seed`

which generates a seed in the database/seeds in project folder.

Command has argument {classname=AdminTablesSeeder}, its allows you to set a custom name for the seed.
The --users option allows you to additionally export to seed users' tables and their relationships with roles and permissions.

Seed can be apply on another server at any time with a command

`php artisan db:seed --class=AdminTablesSeeder`

WARNING: Seed overwrites existing tables, completely replacing the contents of the data from the seed.

If you use just run admin:export-seed (without --users option) you can add new menu items, roles and permissions, export them to seed and apply them on another server without fear of data loss.

WARNING: if you delete roles or permissions, after applying them to another server, save the corresponding relations in users.