### PR TITLE
Add data property in Field class

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -34,6 +34,13 @@ class Field implements Renderable
     protected $value;
 
     /**
+     * Data of all original columns of value.
+     *
+     * @var mixed
+     */
+    protected $data;
+
+    /**
      * Field original value.
      *
      * @var mixed
@@ -332,6 +339,8 @@ class Field implements Renderable
 //            return;
 //        }
 
+        $this->data = $data;
+
         if (is_array($this->column)) {
             foreach ($this->column as $key => $column) {
                 $this->value[$key] = array_get($data, $column);
@@ -558,6 +567,24 @@ class Field implements Renderable
         }
 
         $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set or get data.
+     *
+     * @param array $data
+     *
+     * @return $this
+     */
+    public function data(array $data = null)
+    {
+        if (is_null($data)) {
+            return $this->data;
+        }
+
+        $this->data = $data;
 
         return $this;
     }


### PR DESCRIPTION
I added "$data" property in Field.php.
We can get the "column"'s value, but we can not get "model"'s values or posted values.

Especially, we are very hard getting values in "hasMany" field after.

So I added "$data" property. We can get all of values after.