### PR TITLE
Callback field in select options

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -34,6 +34,13 @@ class Field implements Renderable
     protected $value;
 
     /**
+     * Data of all original columns of value.
+     *
+     * @var mixed
+     */
+    protected $data;
+
+    /**
      * Field original value.
      *
      * @var mixed
@@ -332,6 +339,8 @@ class Field implements Renderable
 //            return;
 //        }
 
+        $this->data = $data;
+
         if (is_array($this->column)) {
             foreach ($this->column as $key => $column) {
                 $this->value[$key] = array_get($data, $column);
@@ -558,6 +567,24 @@ class Field implements Renderable
         }
 
         $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set or get data.
+     *
+     * @param array $data
+     *
+     * @return $this
+     */
+    public function data(array $data = null)
+    {
+        if (is_null($data)) {
+            return $this->data;
+        }
+
+        $this->data = $data;
 
         return $this;
     }

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -381,7 +381,7 @@ EOT;
                 $this->options = $this->options->bindTo($this->form->model());
             }
 
-            $this->options(call_user_func($this->options, $this->value));
+            $this->options(call_user_func($this->options, $this->value, $this));
         }
 
         $this->options = array_filter($this->options, 'strlen');


### PR DESCRIPTION
Using select - options function,  we can get options with callback function
ex.
~~~ php
$form->select('baz')->options(function($value){
    return ['1' => 'foo', '2' => 'bar'];
});
~~~

But $value property is only the value user selected.
So we cannot get other information.
(Using "$this" property in options function, we can get the model. But in "hasmany" field, "$this" is parent model, not children's model.)

So I modify.
If we want to get $field, please write as below.
ex.
~~~ php
$form->select('baz')->options(function($value, $field){
    return ['1' => 'foo', '2' => 'bar'];
});
~~~

We can get $field instance(this example, $field is Select instance.)
If PL #2983 is OK, executing "$field->data()", We can get other's value (of course contains ID and value user edited form.)
