### PR TITLE
callback_field_in_select_options

### DIFF
--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -381,7 +381,7 @@ EOT;
                 $this->options = $this->options->bindTo($this->form->model());
             }
 
-            $this->options(call_user_func($this->options, $this->value));
+            $this->options(call_user_func($this->options, $this->value, $this));
         }
 
         $this->options = array_filter($this->options, 'strlen');


### PR DESCRIPTION
Using select - options function, we can get options with callback function
ex.
~~~ php
$form->select('baz')->options(function($value){
    return ['1' => 'foo', '2' => 'bar'];
});
~~~

But $value property is only the value user selected.
So we cannot get other information.
(Using "$this" property in options function, we can get the model. But in "hasmany" field, "$this" is parent model, not children's model.)

So I modify.
If we want to get $field, please write as below.
ex.
~~~ php
$form->select('baz')->options(function($value, $field){
    return ['1' => 'foo', '2' => 'bar'];
});
~~~ 

We can get $field instance(this example, $field is Select instance.)
If PL #2983 is OK, executing "$field->data()", We can get other's value (of course contains ID and value user edited form.)