### PR TITLE
Support SubDirectory URL

### DIFF
--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -25,13 +25,13 @@
 <body class="hold-transition login-page" @if(config('admin.login_background_image'))style="background: url({{config('admin.login_background_image')}}) no-repeat;background-size: cover;"@endif>
 <div class="login-box">
   <div class="login-logo">
-    <a href="{{ admin_base_path('/') }}"><b>{{config('admin.name')}}</b></a>
+    <a href="{{ admin_url('/') }}"><b>{{config('admin.name')}}</b></a>
   </div>
   <!-- /.login-logo -->
   <div class="login-box-body">
     <p class="login-box-msg">{{ trans('admin.login') }}</p>
 
-    <form action="{{ admin_base_path('auth/login') }}" method="post">
+    <form action="{{ admin_url('auth/login') }}" method="post">
       <div class="form-group has-feedback {!! !$errors->has('username') ?: 'has-error' !!}">
 
         @if($errors->has('username'))

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -2,7 +2,7 @@
 <header class="main-header">
 
     <!-- Logo -->
-    <a href="{{ admin_base_path('/') }}" class="logo">
+    <a href="{{ admin_url('/') }}" class="logo">
         <!-- mini logo for sidebar mini 50x50 pixels -->
         <span class="logo-mini">{!! config('admin.logo-mini', config('admin.name')) !!}</span>
         <!-- logo for regular state and mobile devices -->
@@ -45,10 +45,10 @@
                         </li>
                         <li class="user-footer">
                             <div class="pull-left">
-                                <a href="{{ admin_base_path('auth/setting') }}" class="btn btn-default btn-flat">{{ trans('admin.setting') }}</a>
+                                <a href="{{ admin_url('auth/setting') }}" class="btn btn-default btn-flat">{{ trans('admin.setting') }}</a>
                             </div>
                             <div class="pull-right">
-                                <a href="{{ admin_base_path('auth/logout') }}" class="btn btn-default btn-flat">{{ trans('admin.logout') }}</a>
+                                <a href="{{ admin_url('auth/logout') }}" class="btn btn-default btn-flat">{{ trans('admin.logout') }}</a>
                             </div>
                         </li>
                     </ul>

--- a/resources/views/partials/menu.blade.php
+++ b/resources/views/partials/menu.blade.php
@@ -4,7 +4,7 @@
             @if(url()->isValidUrl($item['uri']))
                 <a href="{{ $item['uri'] }}" target="_blank">
             @else
-                 <a href="{{ admin_base_path($item['uri']) }}">
+                 <a href="{{ admin_url($item['uri']) }}">
             @endif
                 <i class="fa {{$item['icon']}}"></i>
                 @if (Lang::has($titleTranslation = 'admin.menu_titles.' . trim(str_replace(' ', '_', strtolower($item['title'])))))

--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -80,11 +80,13 @@ class MenuController extends Controller
                 if (!isset($branch['children'])) {
                     if (url()->isValidUrl($branch['uri'])) {
                         $uri = $branch['uri'];
+                        $label = $branch['uri'];
                     } else {
-                        $uri = admin_base_path($branch['uri']);
+                        $uri = admin_url($branch['uri']);
+                        $label = admin_base_path($branch['uri']);
                     }
 
-                    $payload .= "&nbsp;&nbsp;&nbsp;<a href=\"$uri\" class=\"dd-nodrag\">$uri</a>";
+                    $payload .= "&nbsp;&nbsp;&nbsp;<a href=\"$uri\" class=\"dd-nodrag\">$label</a>";
                 }
 
                 return $payload;

--- a/src/Form.php
+++ b/src/Form.php
@@ -8,6 +8,7 @@ use Encore\Admin\Form\Builder;
 use Encore\Admin\Form\Field;
 use Encore\Admin\Form\Row;
 use Encore\Admin\Form\Tab;
+use Encore\Admin\Traits\Resource;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations;
@@ -71,6 +72,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class Form implements Renderable
 {
+    use Resource;
+
     /**
      * Eloquent model of the form.
      *
@@ -590,7 +593,7 @@ class Form implements Renderable
      */
     protected function redirectAfterStore()
     {
-        $resourcesPath = $this->resource(0);
+        $resourcesPath = $this->getResource(0);
 
         $key = $this->model->getKey();
 
@@ -606,7 +609,7 @@ class Form implements Renderable
      */
     protected function redirectAfterUpdate($key)
     {
-        $resourcesPath = $this->resource(-1);
+        $resourcesPath = $this->getResource(-1);
 
         return $this->redirectAfterSaving($resourcesPath, $key);
     }
@@ -1352,13 +1355,7 @@ class Form implements Renderable
      */
     public function resource($slice = -2)
     {
-        $segments = explode('/', trim(app('request')->getUri(), '/'));
-
-        if ($slice != 0) {
-            $segments = array_slice($segments, 0, $slice);
-        }
-
-        return implode('/', $segments);
+        return $this->getResource($slice);
     }
 
     /**

--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -482,7 +482,7 @@ class Builder
 
         $this->addRedirectUrlField();
 
-        $attributes['action'] = $this->getAction();
+        $attributes['action'] = url($this->getAction());
         $attributes['method'] = array_get($options, 'method', 'post');
         $attributes['accept-charset'] = 'UTF-8';
 

--- a/src/Form/Tools.php
+++ b/src/Form/Tools.php
@@ -165,10 +165,11 @@ class Tools implements Renderable
     protected function renderList()
     {
         $text = trans('admin.list');
+        $url = url($this->getListPath());
 
         return <<<EOT
 <div class="btn-group pull-right" style="margin-right: 5px">
-    <a href="{$this->getListPath()}" class="btn btn-sm btn-default" title="$text"><i class="fa fa-list"></i><span class="hidden-xs">&nbsp;$text</span></a>
+    <a href="{$url}" class="btn btn-sm btn-default" title="$text"><i class="fa fa-list"></i><span class="hidden-xs">&nbsp;$text</span></a>
 </div>
 EOT;
     }
@@ -181,10 +182,11 @@ EOT;
     protected function renderView()
     {
         $view = trans('admin.view');
+        $url = url($this->getViewPath());
 
         return <<<HTML
 <div class="btn-group pull-right" style="margin-right: 5px">
-    <a href="{$this->getViewPath()}" class="btn btn-sm btn-primary" title="{$view}">
+    <a href="{$url}" class="btn btn-sm btn-primary" title="{$view}">
         <i class="fa fa-eye"></i><span class="hidden-xs"> {$view}</span>
     </a>
 </div>
@@ -201,6 +203,7 @@ HTML;
         $deleteConfirm = trans('admin.delete_confirm');
         $confirm = trans('admin.confirm');
         $cancel = trans('admin.cancel');
+        $url = url($this->getDeletePath());
 
         $class = uniqid();
 
@@ -220,7 +223,7 @@ $('.{$class}-delete').unbind('click').click(function() {
             return new Promise(function(resolve) {
                 $.ajax({
                     method: 'post',
-                    url: '{$this->getDeletePath()}',
+                    url: '{$url}',
                     data: {
                         _method:'delete',
                         _token:LA.token,

--- a/src/Form/Tools.php
+++ b/src/Form/Tools.php
@@ -204,6 +204,7 @@ HTML;
         $confirm = trans('admin.confirm');
         $cancel = trans('admin.cancel');
         $url = url($this->getDeletePath());
+        $listUrl = url($this->getListPath());
 
         $class = uniqid();
 
@@ -229,7 +230,7 @@ $('.{$class}-delete').unbind('click').click(function() {
                         _token:LA.token,
                     },
                     success: function (data) {
-                        $.pjax({container:'#pjax-container', url: '{$this->getListPath()}' });
+                        $.pjax({container:'#pjax-container', url: '{$listUrl}' });
 
                         resolve(data);
                     }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -13,6 +13,7 @@ use Encore\Admin\Grid\HasElementNames;
 use Encore\Admin\Grid\Model;
 use Encore\Admin\Grid\Row;
 use Encore\Admin\Grid\Tools;
+use Encore\Admin\Traits\Resource;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations;
 use Illuminate\Support\Collection;
@@ -21,7 +22,7 @@ use Jenssegers\Mongodb\Eloquent\Model as MongodbModel;
 
 class Grid
 {
-    use HasElementNames;
+    use HasElementNames, Resource;
 
     /**
      * The grid data model instance.
@@ -710,7 +711,7 @@ class Grid
             $input = array_merge($input, $constraints);
         }
 
-        return $this->resource().'?'.http_build_query($input);
+        return url($this->resource()).'?'.http_build_query($input);
     }
 
     /**
@@ -727,7 +728,7 @@ class Grid
         }
 
         return sprintf('%s/create%s',
-            $this->resource(),
+            url($this->resource()),
             $queryString ? ('?'.$queryString) : ''
         );
     }
@@ -865,7 +866,7 @@ class Grid
             return $this->resourcePath;
         }
 
-        return app('request')->getPathInfo();
+        return $this->getResource(0);
     }
 
     /**

--- a/src/Grid/Displayers/Actions.php
+++ b/src/Grid/Displayers/Actions.php
@@ -144,8 +144,9 @@ class Actions extends AbstractDisplayer
      */
     protected function renderView()
     {
+        $uri = url($this->getResource());
         return <<<EOT
-<a href="{$this->getResource()}/{$this->getKey()}">
+<a href="{$uri}/{$this->getKey()}">
     <i class="fa fa-eye"></i>
 </a>
 EOT;
@@ -158,8 +159,9 @@ EOT;
      */
     protected function renderEdit()
     {
+        $uri = url($this->getResource());
         return <<<EOT
-<a href="{$this->getResource()}/{$this->getKey()}/edit">
+<a href="{$uri}/{$this->getKey()}/edit">
     <i class="fa fa-edit"></i>
 </a>
 EOT;
@@ -175,6 +177,7 @@ EOT;
         $deleteConfirm = trans('admin.delete_confirm');
         $confirm = trans('admin.confirm');
         $cancel = trans('admin.cancel');
+        $uri = url($this->getResource());
 
         $script = <<<SCRIPT
 
@@ -194,7 +197,7 @@ $('.{$this->grid->getGridRowName()}-delete').unbind('click').click(function() {
             return new Promise(function(resolve) {
                 $.ajax({
                     method: 'post',
-                    url: '{$this->getResource()}/' + id,
+                    url: '{$uri}/' + id,
                     data: {
                         _method:'delete',
                         _token:LA.token,

--- a/src/Grid/Displayers/Actions.php
+++ b/src/Grid/Displayers/Actions.php
@@ -145,6 +145,7 @@ class Actions extends AbstractDisplayer
     protected function renderView()
     {
         $uri = url($this->getResource());
+
         return <<<EOT
 <a href="{$uri}/{$this->getKey()}">
     <i class="fa fa-eye"></i>
@@ -160,6 +161,7 @@ EOT;
     protected function renderEdit()
     {
         $uri = url($this->getResource());
+
         return <<<EOT
 <a href="{$uri}/{$this->getKey()}/edit">
     <i class="fa fa-edit"></i>

--- a/src/Grid/Tools/BatchDelete.php
+++ b/src/Grid/Tools/BatchDelete.php
@@ -17,6 +17,7 @@ class BatchDelete extends BatchAction
         $deleteConfirm = trans('admin.delete_confirm');
         $confirm = trans('admin.confirm');
         $cancel = trans('admin.cancel');
+        $url = url($this->resource);
 
         return <<<EOT
 
@@ -36,7 +37,7 @@ $('{$this->getElementClass()}').on('click', function() {
             return new Promise(function(resolve) {
                 $.ajax({
                     method: 'post',
-                    url: '{$this->resource}/' + id,
+                    url: '{$url}/' + id,
                     data: {
                         _method:'delete',
                         _token:'{$this->getToken()}'

--- a/src/Show.php
+++ b/src/Show.php
@@ -6,6 +6,7 @@ use Encore\Admin\Show\Divider;
 use Encore\Admin\Show\Field;
 use Encore\Admin\Show\Panel;
 use Encore\Admin\Show\Relation;
+use Encore\Admin\Traits\Resource;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -21,6 +22,8 @@ use Illuminate\Support\Collection;
 
 class Show implements Renderable
 {
+    use Resource;
+
     /**
      * The Eloquent model to show.
      *
@@ -276,12 +279,7 @@ class Show implements Renderable
     public function getResourcePath()
     {
         if (empty($this->resource)) {
-            $path = request()->path();
-
-            $segments = explode('/', $path);
-            array_pop($segments);
-
-            $this->resource = implode('/', $segments);
+            $this->resource = $this->getResource(-1);
         }
 
         return $this->resource;

--- a/src/Show/Tools.php
+++ b/src/Show/Tools.php
@@ -175,10 +175,11 @@ class Tools implements Renderable
     protected function renderList()
     {
         $list = trans('admin.list');
+        $url = url($this->getListPath());
 
         return <<<HTML
 <div class="btn-group pull-right" style="margin-right: 5px">
-    <a href="{$this->getListPath()}" class="btn btn-sm btn-default" title="{$list}">
+    <a href="{$url}" class="btn btn-sm btn-default" title="{$list}">
         <i class="fa fa-list"></i><span class="hidden-xs"> {$list}</span>
     </a>
 </div>
@@ -193,10 +194,11 @@ HTML;
     protected function renderEdit()
     {
         $edit = trans('admin.edit');
+        $url = url($this->getEditPath());
 
         return <<<HTML
 <div class="btn-group pull-right" style="margin-right: 5px">
-    <a href="{$this->getEditPath()}" class="btn btn-sm btn-primary" title="{$edit}">
+    <a href="{$url}" class="btn btn-sm btn-primary" title="{$edit}">
         <i class="fa fa-edit"></i><span class="hidden-xs"> {$edit}</span>
     </a>
 </div>
@@ -213,6 +215,7 @@ HTML;
         $deleteConfirm = trans('admin.delete_confirm');
         $confirm = trans('admin.confirm');
         $cancel = trans('admin.cancel');
+        $url = url($this->getDeletePath());
 
         $class = uniqid();
 
@@ -232,7 +235,7 @@ $('.{$class}-delete').unbind('click').click(function() {
             return new Promise(function(resolve) {
                 $.ajax({
                     method: 'post',
-                    url: '{$this->getDeletePath()}',
+                    url: '{$url}',
                     data: {
                         _method:'delete',
                         _token:LA.token,

--- a/src/Show/Tools.php
+++ b/src/Show/Tools.php
@@ -216,6 +216,7 @@ HTML;
         $confirm = trans('admin.confirm');
         $cancel = trans('admin.cancel');
         $url = url($this->getDeletePath());
+        $listUrl = url($this->getListPath());
 
         $class = uniqid();
 
@@ -241,7 +242,7 @@ $('.{$class}-delete').unbind('click').click(function() {
                         _token:LA.token,
                     },
                     success: function (data) {
-                        $.pjax({container:'#pjax-container', url: '{$this->getListPath()}' });
+                        $.pjax({container:'#pjax-container', url: '{$listUrl}' });
 
                         resolve(data);
                     }

--- a/src/Traits/Resource.php
+++ b/src/Traits/Resource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Encore\Admin\Traits;
+
+trait Resource
+{
+    /**
+     * get resource to grid
+     */
+    protected function getResource($slice){
+        // create uri
+        $segments = [];
+        
+        // set url
+        foreach (explode('/', trim(app('request')->getPathInfo(), '/')) as $value) {
+            $segments[] = $value;
+        }
+
+        if ($slice != 0) {
+            $segments = array_slice($segments, 0, $slice);
+        }
+
+        return '/'.implode('/', $segments);
+    }
+}

--- a/src/Traits/Resource.php
+++ b/src/Traits/Resource.php
@@ -5,12 +5,13 @@ namespace Encore\Admin\Traits;
 trait Resource
 {
     /**
-     * get resource to grid
+     * get resource to grid.
      */
-    protected function getResource($slice){
+    protected function getResource($slice)
+    {
         // create uri
         $segments = [];
-        
+
         // set url
         foreach (explode('/', trim(app('request')->getPathInfo(), '/')) as $value) {
             $segments[] = $value;

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -85,7 +85,7 @@ class Tree implements Renderable
     {
         $this->model = $model;
 
-        $this->path = app('request')->getPathInfo();
+        $this->path = url(app('request')->getPathInfo());
         $this->elementId .= uniqid();
 
         $this->setupTools();

--- a/src/Widgets/Form.php
+++ b/src/Widgets/Form.php
@@ -269,6 +269,11 @@ class Form implements Renderable
 
         $html = [];
         foreach ($attributes as $key => $val) {
+            // set action as absolute url
+            if($key == 'action'){
+                $val = url($val);
+            }
+
             $html[] = "$key=\"$val\"";
         }
 

--- a/src/Widgets/Form.php
+++ b/src/Widgets/Form.php
@@ -270,7 +270,7 @@ class Form implements Renderable
         $html = [];
         foreach ($attributes as $key => $val) {
             // set action as absolute url
-            if($key == 'action'){
+            if ($key == 'action') {
                 $val = url($val);
             }
 

--- a/tests/UserGridTest.php
+++ b/tests/UserGridTest.php
@@ -43,8 +43,8 @@ class UserGridTest extends TestCase
             ->seeElement("form[action='$action'][method=get] input[name='profile[end_at][start]']")
             ->seeElement("form[action='$action'][method=get] input[name='profile[end_at][end]']");
 
-        $this->seeInElement('a[href="/admin/users?_export_=all"]', 'All')
-            ->seeInElement('a[href="/admin/users/create"]', 'New');
+        $this->seeInElement('a[href="'.$action.'?_export_=all"]', 'All')
+            ->seeInElement('a[href="'.$action.'/create"]', 'New');
     }
 
     protected function seedsTable($count = 100)


### PR DESCRIPTION
Now we can't use for sub-directory ex."http://foobar.com.test/subdir/admin".
Because function "admin_base_path" returns string that starts "/admin".
So the url in blade (ex. login.blade.php) sets "/admin" browser thinks as "http://foobar.com.test/admin", so 404 error.

I modify as blow.
- change "admin_base_path" to "admin_url" in blade.
- change relative url to absolute url in Form, Grid and Show.(ex. Function "renderEdit" sets url "/admin/model/1/edit" to "http://foobar.com.test/subdir/admin/model/1/edit")