### PR TITLE
datalist function for Text form field

### DIFF
--- a/src/Form/Field/Text.php
+++ b/src/Form/Field/Text.php
@@ -32,4 +32,14 @@ class Text extends Field
 
         return parent::render();
     }
+
+    public function datalist( $entries = [] ) {
+        $this->defaultAttribute('list', "list-{$this->id}");
+        $datalist = "<datalist id=\"list-{$this->id}\">";
+        foreach($entries as $k => $v) {
+            $datalist .= "<option value=\"{$k}\">{$v}</option>";
+        }
+        $datalist .= "</datalist>";
+        $this->append($datalist);
+    }
 }


### PR DESCRIPTION
[MDN:datalist](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist)

Implementation for Text field, datalist can be used for autocomplete function on input 
```html
<label for="ice-cream-choice">Choose a flavor:</label>
<input list="ice-cream-flavors" id="ice-cream-choice" name="ice-cream-choice" />

<datalist id="ice-cream-flavors">
    <option value="Chocolate">
    <option value="Coconut">
    <option value="Mint">
    <option value="Strawberry">
    <option value="Vanilla">
</datalist>
```

Usage:
```
$form->text('flavor', 'Flavor')->datalist( Flavor::pluck('name', 'id') );
```
