### PR TITLE
Add function inputmask() for Form\Field\Text::class and child classes

### DIFF
--- a/src/Form/Field/Currency.php
+++ b/src/Form/Field/Currency.php
@@ -67,11 +67,7 @@ class Currency extends Text
      */
     public function render()
     {
-        $options = json_encode($this->options);
-
-        $this->script = <<<EOT
-$('{$this->getElementClassSelector()}').inputmask($options);
-EOT;
+        $this->inputmask($this->options);
 
         $this->prepend($this->symbol)
             ->defaultAttribute('style', 'width: 120px');

--- a/src/Form/Field/Decimal.php
+++ b/src/Form/Field/Decimal.php
@@ -20,9 +20,7 @@ class Decimal extends Text
 
     public function render()
     {
-        $options = json_encode($this->options);
-
-        $this->script = "$('{$this->getElementClassSelector()}').inputmask($options);";
+        $this->inputmask($this->options);
 
         $this->prepend('<i class="fa fa-terminal fa-fw"></i>')
             ->defaultAttribute('style', 'width: 130px');

--- a/src/Form/Field/Ip.php
+++ b/src/Form/Field/Ip.php
@@ -21,12 +21,7 @@ class Ip extends Text
 
     public function render()
     {
-        $options = json_encode($this->options);
-
-        $this->script = <<<EOT
-
-$('{$this->getElementClassSelector()}').inputmask($options);
-EOT;
+        $this->inputmask($this->options);
 
         $this->prepend('<i class="fa fa-laptop fa-fw"></i>')
             ->defaultAttribute('style', 'width: 130px');

--- a/src/Form/Field/Mobile.php
+++ b/src/Form/Field/Mobile.php
@@ -19,42 +19,11 @@ class Mobile extends Text
 
     public function render()
     {
-        $options = $this->json_encode_options($this->options);
-
-        $this->script = <<<EOT
-
-$('{$this->getElementClassSelector()}').inputmask($options);
-EOT;
+        $this->inputmask($this->options);
 
         $this->prepend('<i class="fa fa-phone fa-fw"></i>')
             ->defaultAttribute('style', 'width: 150px');
 
         return parent::render();
-    }
-
-    protected function json_encode_options($options)
-    {
-        $value_arr = [];
-        $replace_keys = [];
-
-        foreach ($options as $key => &$value) {
-            // Look for values starting with 'function('
-            if (strpos($value, 'function(') === 0) {
-                // Store function string.
-                $value_arr[] = $value;
-                // Replace function string in $foo with a 'unique' special key.
-                $value = '%'.$key.'%';
-                // Later on, we'll look for the value, and replace it.
-                $replace_keys[] = '"'.$value.'"';
-            }
-        }
-
-        // Now encode the array to json format
-        $json = json_encode($options);
-
-        // Replace the special keys with the original string.
-        $json = str_replace($replace_keys, $value_arr, $json);
-
-        return $json;
     }
 }

--- a/src/Form/Field/Text.php
+++ b/src/Form/Field/Text.php
@@ -32,4 +32,66 @@ class Text extends Field
 
         return parent::render();
     }
+
+    /**
+     * Add inputmask to an elements.
+     *
+     * @param array $options
+     *
+     * @return $this
+     */
+    public function inputmask($options)
+    {
+        $options = $this->json_encode_options($options);
+
+        $this->script = "$('{$this->getElementClassSelector()}').inputmask($options);";
+
+        return $this;
+    }
+
+    /**
+     * Encode options to Json.
+     *
+     * @param array $options
+     *
+     * @return $json
+     */
+    protected function json_encode_options($options)
+    {
+        $data = $this->prepare_options($options);
+
+        $json = json_encode($data['options']);
+
+        $json = str_replace($data['toReplace'], $data['original'], $json);
+
+        return $json;
+    }
+
+    /**
+     * Prepare options.
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function prepare_options($options)
+    {
+        $original = [];
+        $toReplace = [];
+
+        foreach ($options as $key => &$value) {
+            if (is_array($value)) {
+                $subArray = $this->prepare_options($value);
+                $value = $subArray['options'];
+                $original = array_merge($original, $subArray['original']);
+                $toReplace = array_merge($toReplace, $subArray['toReplace']);
+            } elseif (preg_match('/function.*?/', $value)) {
+                $original[] = $value;
+                $value = "%{$key}%";
+                $toReplace[] = "\"{$value}\"";
+            }
+        }
+
+        return compact('original', 'toReplace', 'options');
+    }
 }


### PR DESCRIPTION
Usage:
```
$form->text('email', 'E-mail')->inputmask([   
    'mask' => '*{1,20}[.*{1,20}][.*{1,20}][.*{1,20}]@*{1,20}[.*{2,6}][.*{1,2}]',   
    'greedy' => false,   
    'onBeforePaste' => 'function(pastedValue, opts) { pastedValue = pastedValue.toLowerCase(); return pastedValue.replace("mailto:", ""); }',   
    'definitions' => [   
        '*'  => [   
            'validator' => "[0-9A-Za-z!#$%&'*+/=?^_`{|}~\-]",   
            'casing' => "lower"   
        ]   
    ]   
]);   
```

With some types of inputs inputmask don't work: [allowed html elements](https://github.com/RobinHerbots/Inputmask#allowed-html-elements).
So for example to make an email input with inputmask it will need to be type text.