### PR TITLE
Intervention BugFix

### DIFF
--- a/src/Form/Field/Image.php
+++ b/src/Form/Field/Image.php
@@ -35,7 +35,7 @@ class Image extends File
 
         $path = $this->uploadAndDeleteOriginal($image);
 
-        $fullPath = $this->options['path_prefix'] . $path;
+        $fullPath = $this->options['path_prefix'].$path;
 
         $this->callInterventionMethods($fullPath);
 

--- a/src/Form/Field/Image.php
+++ b/src/Form/Field/Image.php
@@ -33,8 +33,12 @@ class Image extends File
 
         $this->name = $this->getStoreName($image);
 
-        $this->callInterventionMethods($image->getRealPath());
+        $path = $this->uploadAndDeleteOriginal($image);
 
-        return $this->uploadAndDeleteOriginal($image);
+        $fullPath = $this->options['path_prefix'] . $path;
+
+        $this->callInterventionMethods($fullPath);
+
+        return $path;
     }
 }


### PR DESCRIPTION
After the patch all operations with Intervention will be available.
Example for using:

```php
$form->image('thumbnail')->options([
       'path_prefix' => public_path('uploads') . '/',
])->move('tour_video_thumbs')->fit(200);
```
Any ideas how to remove **path_prefix** are welcome?