### PR TITLE
Fixed Bug on Action label of Grid

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -467,7 +467,7 @@ class Grid
      */
     protected function appendActionsColumn()
     {
-        if (!$this->option('useActions')) {
+        if (!$this->option('useActions') or $this->model->eloquent()->count() == 0) {
             return;
         }
 

--- a/src/Grid/Displayers/Actions.php
+++ b/src/Grid/Displayers/Actions.php
@@ -134,6 +134,13 @@ class Actions extends AbstractDisplayer
 
         $actions = array_merge($actions, $this->appends);
 
+        if(empty($actions)){
+            $this->grid->columns()->search(function($value,$key)
+            {
+                return  $value->getName() == '__actions__' ? $this->grid->columns()->forget($key) : "";
+            });
+        }
+
         return implode('', $actions);
     }
 

--- a/src/Grid/Displayers/Actions.php
+++ b/src/Grid/Displayers/Actions.php
@@ -134,9 +134,9 @@ class Actions extends AbstractDisplayer
 
         $actions = array_merge($actions, $this->appends);
 
-        if(empty($actions)) {
-            $this->grid->columns()->search(function($value, $key) {
-                return  $value->getName() == '__actions__' ? $this->grid->columns()->forget($key) : '';
+        if (empty($actions)) {
+            $this->grid->columns()->search(function ($value, $key) {
+                return  $value->getName() == '__actions__' ? $this->grid->columns()->forget($key) : "";
             });
         }
 

--- a/src/Grid/Displayers/Actions.php
+++ b/src/Grid/Displayers/Actions.php
@@ -134,10 +134,9 @@ class Actions extends AbstractDisplayer
 
         $actions = array_merge($actions, $this->appends);
 
-        if(empty($actions)){
-            $this->grid->columns()->search(function($value,$key)
-            {
-                return  $value->getName() == '__actions__' ? $this->grid->columns()->forget($key) : "";
+        if(empty($actions)) {
+            $this->grid->columns()->search(function($value, $key) {
+                return  $value->getName() == '__actions__' ? $this->grid->columns()->forget($key) : '';
             });
         }
 

--- a/src/Grid/Displayers/Actions.php
+++ b/src/Grid/Displayers/Actions.php
@@ -136,7 +136,7 @@ class Actions extends AbstractDisplayer
 
         if (empty($actions)) {
             $this->grid->columns()->search(function ($value, $key) {
-                return  $value->getName() == '__actions__' ? $this->grid->columns()->forget($key) : "";
+                return  $value->getName() == '__actions__' ? $this->grid->columns()->forget($key) : '';
             });
         }
 


### PR DESCRIPTION
There is a bug while disabling actions of Grid . 

When you disable actions on Grid.php with changing useActions to false from true everything is working well .

But when you disable all actions with functions the bug grown , for example : 

```
   $grid->actions(function ($actions) {
                        $actions->disableEdit();
                        $actions->disableDelete();
                        $actions->disableView();
                    });
```
with this example display will be such , please make attention to red line :

[
![screenshot_2](https://user-images.githubusercontent.com/11161906/52709351-fb13d100-2fa5-11e9-914b-bf9f9f215807.png)
](url)

 In this situation must be not shown the action label . My PR will be fix this problem .



