### PR TITLE
 重设列class名称

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -987,9 +987,27 @@ class Field implements Renderable
         }
 
         foreach ($delClass as $del) {
-            if (($key = array_search($del, $this->elementClass))) {
+            if (($key = array_search($del, $this->elementClass)) !== false) {
                 unset($this->elementClass[$key]);
             }
+        }
+
+        return $this;
+    }
+
+    /**
+     * reset field className
+     *
+     * @param string $className
+     * @param string $resetClassName
+     *
+     * @return $this
+     */
+    public function resetElementClassName(string $className, string $resetClassName)
+    {
+        if (($key = array_search($className, $this->getElementClass())) !== false) {
+
+            $this->elementClass[$key] = $resetClassName;
         }
 
         return $this;


### PR DESCRIPTION
关于 issue #2807 [https://github.com/z-song/laravel-admin/issues/2807](url)
所提到的数据库字段为“ label” 会被隐藏的问题，
1. 目前的removeElementClass不能remove掉默认增加的字段名称，而且此方法目前判断是否存在class名称的方法有问题，在被array_search的数组中，如果search到第一个即key为0时，if条件将不成立，array_search在找不大目标时会返回false，所以需要判断是否返回false。

2. 新增一个resetElementClassName方法来解决默认数据库字段可能被隐藏的问题，而且不能直接unset，否则还会被追加默认字段到列的class中，所以需要将其置为需要的名称或者空。即此方法实际上是一个将class取别名的功能。