### PR TITLE
优化权限检查时的兼容性

### DIFF
--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -75,7 +75,7 @@ class Permission extends Model
             }
 
             return compact('method', 'path');
-        }, explode("\r\n", $this->http_path));
+        }, explode("\n", $this->http_path));
 
         foreach ($matches as $match) {
             if ($this->matchRequest($match, $request)) {
@@ -86,6 +86,17 @@ class Permission extends Model
         return false;
     }
 
+    /**
+     * filter \r
+     * 
+     * @param string  $path
+     * @return mixed
+     */
+    public function getHttpPathAttribute($path)
+    {
+        return str_replace("\r\n", "\n", $path);
+    }
+    
     /**
      * If a request match the specific HTTP method and path.
      *

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -91,7 +91,7 @@ class PermissionController extends Controller
         $grid->name(trans('admin.name'));
 
         $grid->http_path(trans('admin.route'))->display(function ($path) {
-            return collect(explode("\r\n", $path))->map(function ($path) {
+            return collect(explode("\n", $path))->map(function ($path) {
                 $method = $this->http_method ?: ['ANY'];
 
                 if (Str::contains($path, ':')) {


### PR DESCRIPTION
使用Git管理代码时，Git会自动把CRLF（\r\n）转化为LF(\n)，在Linux系统下，就会出现这种情况：把permission的种子文件加入代码库->从代码库clone出permisons种子文件->把permissions种子文件导入数据库，这时在git已经把\r\n转变成了\n，所以admin_permissons表中的权限配置就只有\n分隔的路由，造成权限检查出错和下图中所示的情况。如果权限种子文件中保存了大量的权限数据，后动去更正是不在合适的。
本次提交纠正了这方面的问题。

![image](https://user-images.githubusercontent.com/16495687/53945723-2d27d700-40fd-11e9-8c73-55b5ce3ae581.png)

Git will convert CRLF to LF automaticly. So on linux OS,  pull codes from repository and then run "php artisan db:seed " to initiate permissions data, because all \r have been removed, so some permission data will be wrong, and User will be denied. this commit has solved this problem. 