### PR TITLE
Number 类去掉默认值类型转换

### DIFF
--- a/src/Form/Field/Number.php
+++ b/src/Form/Field/Number.php
@@ -10,7 +10,7 @@ class Number extends Text
 
     public function render()
     {
-        $this->default((int) $this->default);
+        $this->default($this->default);
 
         $this->script = <<<EOT
 


### PR DESCRIPTION
如果default是回调函数就会出现如下报错：
`$form->number('num', 'num')->default(function ($form) { return $form->model()->num; })->min(0);`
Object of class Closure could not be converted to int