### PR TITLE
修复当自定义Admin目录时，admin:make 命令命名空间的 bug

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -159,11 +159,7 @@ class MakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        $directory = config('admin.directory');
-
-        $namespace = ucfirst(basename($directory));
-
-        return $rootNamespace."\\$namespace\Controllers";
+        return config('admin.route.namespace');
     }
 
     /**


### PR DESCRIPTION
在 admin.php 文件中设置自定义目录时（将Admin的Controller文件跟项目其他Controller同级）：
```
 'directory' => app_path('Http/Controllers/Admin'),
```
basename() 方法还是取到 Admin。不如获取 config('admin.route.namespace') 这个值。