### PR TITLE
Feature Select2 Addon

### DIFF
--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -61,7 +61,7 @@ class Select extends Field
         if (is_callable($options)) {
             $this->options = $options;
         } else {
-            $this->options = (array) $options;
+            $this->options = (array)$options;
         }
 
         return $this;
@@ -96,26 +96,32 @@ class Select extends Field
         return $this;
     }
 
-    public function template(array $view)
+    private function template($key, $val)
     {
-        $view = array_intersect_key($view, array_flip(['result', 'selection']));
-        if ($view) {
-            $this->config['escapeMarkup'] = 'function (markup) {return markup;}';
-            foreach ($view as $key => $val) {
-                $key = ucfirst(strtolower($key));
-                $func_key = "template{$key}";
-                $func_name = str_replace('.', '', "{$this->getElementClassSelector()}_{$key}");
-                $this->config[$func_key] = $func_name;
-                $script = implode("\n", [
-                    "{$func_name} = function(data) {",
-                    "\tif ( !data.id || data.loading) return data.text;",
-                    $val,
-                    '}',
-                ]);
-                Admin::script($script);
-            }
-        }
+        $this->config['escapeMarkup'] = 'function (markup) {return markup;}';
 
+        $key = strtolower($key);
+        $func_key = "template" . ucfirst($key);
+        $func_name = str_replace('.', '', "{$this->getElementClassSelector()}_{$key}");
+        $this->config[$func_key] = $func_name;
+        $script = implode("\n", [
+            "{$func_name} = function(data) {",
+            "\tif ( !data.id || data.loading) return data.text;",
+            $val,
+            '}',
+        ]);
+        Admin::script($script);
+    }
+
+    public function templateResult(string $view)
+    {
+        $this->template('result', $view);
+        return $this;
+    }
+
+    public function templateSelection(string $view)
+    {
+        $this->template('selection', $view);
         return $this;
     }
 
@@ -163,7 +169,7 @@ EOT;
                     return  in_array($u, $functions) ? "{$u}: {$v}" : "{$u}: \"{$v}\"";
                 }
 
-                return "{$u}: ".json_encode($v);
+                return "{$u}: " . json_encode($v);
             }, array_keys($options), $options)
         );
     }
@@ -185,7 +191,7 @@ EOT;
         );
         $configs = $this->buildJsJson($configs);
 
-        return $quoted ? '{'.$configs.'}' : $configs;
+        return $quoted ? '{' . $configs . '}' : $configs;
     }
 
     /**
@@ -337,7 +343,7 @@ EOT;
     protected function loadRemoteOptions($url, $parameters = [], $options = [])
     {
         $ajaxOptions = [
-            'url' => $url.'?'.http_build_query($parameters),
+            'url' => $url . '?' . http_build_query($parameters),
         ];
 
         $configs = $this->configs([
@@ -453,7 +459,7 @@ EOT;
      */
     public function render()
     {
-        Admin::js('https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/'.app()->getLocale().'.js');
+        Admin::js('https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/' . app()->getLocale() . '.js');
         $configs = str_replace("\n", '', $this->configs(
             [
                 'allowClear'  => true,
@@ -486,7 +492,7 @@ EOT;
             'groups'  => $this->groups,
         ]);
 
-        $this->attribute('data-value', implode(',', (array) $this->value()));
+        $this->attribute('data-value', implode(',', (array)$this->value()));
 
         return parent::render();
     }

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -61,7 +61,7 @@ class Select extends Field
         if (is_callable($options)) {
             $this->options = $options;
         } else {
-            $this->options = (array)$options;
+            $this->options = (array) $options;
         }
 
         return $this;
@@ -101,7 +101,7 @@ class Select extends Field
         $this->config['escapeMarkup'] = 'function (markup) {return markup;}';
 
         $key = strtolower($key);
-        $func_key = "template" . ucfirst($key);
+        $func_key = 'template'.ucfirst($key);
         $func_name = str_replace('.', '', "{$this->getElementClassSelector()}_{$key}");
         $this->config[$func_key] = $func_name;
         $script = implode("\n", [
@@ -116,12 +116,14 @@ class Select extends Field
     public function templateResult(string $view)
     {
         $this->template('result', $view);
+
         return $this;
     }
 
     public function templateSelection(string $view)
     {
         $this->template('selection', $view);
+
         return $this;
     }
 
@@ -169,7 +171,7 @@ EOT;
                     return  in_array($u, $functions) ? "{$u}: {$v}" : "{$u}: \"{$v}\"";
                 }
 
-                return "{$u}: " . json_encode($v);
+                return "{$u}: ".json_encode($v);
             }, array_keys($options), $options)
         );
     }
@@ -191,7 +193,7 @@ EOT;
         );
         $configs = $this->buildJsJson($configs);
 
-        return $quoted ? '{' . $configs . '}' : $configs;
+        return $quoted ? '{'.$configs.'}' : $configs;
     }
 
     /**
@@ -343,7 +345,7 @@ EOT;
     protected function loadRemoteOptions($url, $parameters = [], $options = [])
     {
         $ajaxOptions = [
-            'url' => $url . '?' . http_build_query($parameters),
+            'url' => $url.'?'.http_build_query($parameters),
         ];
 
         $configs = $this->configs([
@@ -459,7 +461,7 @@ EOT;
      */
     public function render()
     {
-        Admin::js('https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/' . app()->getLocale() . '.js');
+        Admin::js('https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/'.app()->getLocale().'.js');
         $configs = str_replace("\n", '', $this->configs(
             [
                 'allowClear'  => true,
@@ -492,7 +494,7 @@ EOT;
             'groups'  => $this->groups,
         ]);
 
-        $this->attribute('data-value', implode(',', (array)$this->value()));
+        $this->attribute('data-value', implode(',', (array) $this->value()));
 
         return parent::render();
     }


### PR DESCRIPTION
1.增加TemplateResult和TemplateSelection支持,下面是语法示例

```
        $script = <<<EOT
        return '<span><img style="width:24px" src="/assets/img/world/country/'
        +data.id.toLowerCase()
        +'.png">&nbsp;&nbsp;'
        +data.text+'</span>';
EOT;

        $form->select($field['country'], $label['country'])
            ->options($countries)
            ->load(
                $field['city'],
                admin_url('/api/cities')
            )
            ->value($country)
            ->templateResult($script)
            ->templateSelection($script);
```
2.增加Load/Loads的时候同时加载config数据,主要是为了不丢失Template设置:)
3.把没挂上的语言翻译的select2顺手加上了不过是cdn版的(希望不要让我重开一个PR)