### PR TITLE
UNIQUE表单验证不起作用的BUG

### DIFF
--- a/src/Console/stubs/ExampleController.stub
+++ b/src/Console/stubs/ExampleController.stub
@@ -54,7 +54,7 @@ class ExampleController extends Controller
         return $content
             ->header('Edit')
             ->description('description')
-            ->body($this->form()->edit($id));
+            ->body($this->form($id)->edit($id));
     }
 
     /**
@@ -109,7 +109,7 @@ class ExampleController extends Controller
      *
      * @return Form
      */
-    protected function form()
+    protected function form($id=null)
     {
         $form = new Form(new YourModel);
 

--- a/src/Console/stubs/controller.stub
+++ b/src/Console/stubs/controller.stub
@@ -55,7 +55,7 @@ class DummyClass extends Controller
         return $content
             ->header('Edit')
             ->description('description')
-            ->body($this->form()->edit($id));
+            ->body($this->form($id)->edit($id));
     }
 
     /**
@@ -106,7 +106,7 @@ DummyShow
      *
      * @return Form
      */
-    protected function form()
+    protected function form($id=null)
     {
         $form = new Form(new DummyModel);
 

--- a/src/Controllers/HasResourceActions.php
+++ b/src/Controllers/HasResourceActions.php
@@ -13,7 +13,7 @@ trait HasResourceActions
      */
     public function update($id)
     {
-        return $this->form()->update($id);
+        return $this->form($id)->update($id);
     }
 
     /**


### PR DESCRIPTION
解决form生成的时候需要知道模型主键的问题,比如validation里的unique.