### PR TITLE
fix warning: Parameter #1 $options of method Encore\Admin\Grid\Filter…

### DIFF
--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -238,7 +238,7 @@ abstract class AbstractFilter
     /**
      * Select filter.
      *
-     * @param array $options
+     * @param array|\Illuminate\Support\Collection $options
      *
      * @return Select
      */


### PR DESCRIPTION
fix warning:
```bash
Parameter #1 $options of method Encore\Admin\Grid\Filter\AbstractFilter::select() expects array, Illuminate\Support\Collection given.
```