### PR TITLE
remove use of env() outside config files

### DIFF
--- a/resources/views/partials/exception.blade.php
+++ b/resources/views/partials/exception.blade.php
@@ -1,4 +1,4 @@
-@if($errors->hasBag('exception') && env('APP_DEBUG') == true)
+@if($errors->hasBag('exception') && config('app.debug') == true)
     <?php $error = $errors->getBag('exception');?>
     <div class="alert alert-warning alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>


### PR DESCRIPTION
`env()` does not work when configuration files are cached and should only be used in config files.

`src/Form/Field/Map.php` should be updated as well, and the API keys need to moved to a config file

see [https://laravel.com/docs/5.8/configuration#configuration-caching](https://laravel.com/docs/5.8/configuration#configuration-caching)