### PR TITLE
修复设置后台独立域名和去掉admin.route.prefix后登录无限重定向问题

### DIFF
--- a/src/Middleware/Session.php
+++ b/src/Middleware/Session.php
@@ -12,9 +12,9 @@ class Session
 
         config(['session.path' => $path]);
 
-        if ($domain = config('admin.route.domain')) {
-            config(['session.domain' => $domain]);
-        }
+        // if ($domain = config('admin.route.domain')) {
+        //     config(['session.domain' => $domain]);
+        // }
 
         return $next($request);
     }


### PR DESCRIPTION
去掉设置域名，因为这里设置的域名会导致cookie中的appname_session非hostonly,导致设置了后台独立域名和去掉admin.route.prefix后出现无限重定向问题