### PR TITLE
修复 ->image() 多张图片出错的问题.

### DIFF
--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -199,26 +199,29 @@ class Field implements Renderable
      */
     public function image($server = '', $width = 200, $height = 200)
     {
-        return $this->unescape()->as(function ($path) use ($server, $width, $height) {
-            if (empty($path)) {
-                return '';
-            }
+        return $this->unescape()->as(function ($images) use ($server, $width, $height) {
 
-            if (url()->isValidUrl($path)) {
-                $src = $path;
-            } elseif ($server) {
-                $src = $server.$path;
-            } else {
-                $disk = config('admin.upload.disk');
-
-                if (config("filesystems.disks.{$disk}")) {
-                    $src = Storage::disk($disk)->url($path);
-                } else {
+            return collect($images)->map(function ($path) use ($server, $width, $height) {
+                if (empty($path)) {
                     return '';
                 }
-            }
 
-            return "<img src='$src' style='max-width:{$width}px;max-height:{$height}px' class='img' />";
+                if (url()->isValidUrl($path)) {
+                    $src = $path;
+                } elseif ($server) {
+                    $src = $server . $path;
+                } else {
+                    $disk = config('admin.upload.disk');
+
+                    if (config("filesystems.disks.{$disk}")) {
+                        $src = Storage::disk($disk)->url($path);
+                    } else {
+                        return '';
+                    }
+                }
+
+                return "<img src='$src' style='max-width:{$width}px;max-height:{$height}px' class='img' />";
+            })->implode('&nbsp;');
         });
     }
 

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -200,7 +200,6 @@ class Field implements Renderable
     public function image($server = '', $width = 200, $height = 200)
     {
         return $this->unescape()->as(function ($images) use ($server, $width, $height) {
-
             return collect($images)->map(function ($path) use ($server, $width, $height) {
                 if (empty($path)) {
                     return '';
@@ -209,7 +208,7 @@ class Field implements Renderable
                 if (url()->isValidUrl($path)) {
                     $src = $path;
                 } elseif ($server) {
-                    $src = $server . $path;
+                    $src = $server.$path;
                 } else {
                     $disk = config('admin.upload.disk');
 


### PR DESCRIPTION
Fixes #2723
Fixes #2756

解决 方法
```
$show->imageExtend()->as(function ($items) {
        $paths = [];

        foreach ($items as $item) {
              array_push($paths, $item['image']);
        }

        return $paths;
})->image();
```

imageExtend 方法是hasMany关联方法

```
public function imageExtend() {
        return $this->hasMany(ImageExtend::class, [关联id]);
}
```

如果字段是 json 格式则直接使用，在相应的Model 里加 get、set 属性方法

[https://github.com/z-song/laravel-admin/issues/2756#issuecomment-437795851](url)

$show->images([title]);

