### PR TITLE
Fix bug with missing input mask on filter inputs

### DIFF
--- a/src/Grid/Filter/Presenter/Text.php
+++ b/src/Grid/Filter/Presenter/Text.php
@@ -162,7 +162,7 @@ class Text extends Presenter
     {
         $options = json_encode($options);
 
-        Admin::script("$('#filter-modal input.{$this->filter->getId()}').inputmask($options);");
+        Admin::script("$('#filter-box input.{$this->filter->getId()}').inputmask($options);");
 
         $this->icon = $icon;
 


### PR DESCRIPTION
Inputmask selector by is wrong after default value of filterID property updated