### PR TITLE
add content function for widgets tab

### DIFF
--- a/src/Widgets/Tab.php
+++ b/src/Widgets/Tab.php
@@ -91,6 +91,21 @@ class Tab extends Widget implements Renderable
     }
 
     /**
+     * Set content.
+     *
+     * @param string $title
+     * @param string $content
+     */
+    public function content($title, $content)
+    {
+        foreach ($this->data['tabs'] as $id => $tab) {
+            if ($tab['title'] == $title) {
+                $this->data['tabs'][$id]['content'] = $content;
+            }
+        }
+    }
+
+    /**
      * Set drop-down items.
      *
      * @param array $links


### PR DESCRIPTION
发现tab组件有个缺陷，如果我用addLink方法的时候无法设置内容，所以我在tab类里加了一个设置content的方法，可以设置某个title的tab的内容。
用法：
```php
$tab = new Tab();
$tab->addLink('title1', '/title1/link', true);

// 将设置所有title为title1的内容为'link content'
$tab->content('title1', 'link content');
```