### PR TITLE
修改示例代码的语法错误

### DIFF
--- a/docs/zh/model-grid-actions.md
+++ b/docs/zh/model-grid-actions.md
@@ -87,5 +87,5 @@ $grid->actions(function ($actions) {
     
     // 添加操作
     $actions->append(new CheckRow($actions->getKey()));
-}
+});
 ```


### PR DESCRIPTION
增加底部结束的符号“);” 方便别人直接复制使用