### PR TITLE
Add a config option ‘prefix-permission-ignore’.

### DIFF
--- a/config/admin.php
+++ b/config/admin.php
@@ -60,6 +60,8 @@ return [
 
         'prefix' => env('ADMIN_ROUTE_PREFIX', 'admin'),
 
+        'prefix-permission-ignore' => env('ADMIN_ROUTE_PREFIX_PERMISSION_IGNORE', false),
+
         'namespace' => 'App\\Admin\\Controllers',
 
         'middleware' => ['web', 'admin'],

--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -67,7 +67,9 @@ class Permission extends Model
         $method = $this->http_method;
 
         $matches = array_map(function ($path) use ($method) {
-            $path = trim(config('admin.route.prefix'), '/').$path;
+            if ((config('admin.route.prefix-permission-ignore') !== null) && (config('admin.route.prefix-permission-ignore') === false)) {
+                $path = trim(config('admin.route.prefix'), '/') . $path;
+            }
 
             if (Str::contains($path, ':')) {
                 list($method, $path) = explode(':', $path);

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -106,7 +106,9 @@ class PermissionController extends Controller
                 })->implode('&nbsp;');
 
                 if (!empty(config('admin.route.prefix'))) {
-                    $path = '/'.trim(config('admin.route.prefix'), '/').$path;
+                    if ((config('admin.route.prefix-permission-ignore') !== null) && (config('admin.route.prefix-permission-ignore') === false)) {
+                        $path = '/' . trim(config('admin.route.prefix'), '/') . $path;
+                    }
                 }
 
                 return "<div style='margin-bottom: 5px;'>$method<code>$path</code></div>";


### PR DESCRIPTION
Set the permission-auth to ignore the route-preifx when a route-prefix has been set.