### PR TITLE
Fix file field original value "required" cant submited

### DIFF
--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -183,6 +183,11 @@ class File extends Field
             $this->attribute('data-initial-caption', $this->initialCaption($this->value));
 
             $this->setupPreviewOptions();
+            /**
+             * If has original value, means the form is in edit mode,
+             * then remove required rule from rules.
+             */
+            unset($this->attributes['required']);
         }
 
         $options = json_encode($this->options);


### PR DESCRIPTION
当增加required验证字段，在编辑数据已经有原始数据的时候会提醒让重新传入文件数据
`$form->image('avatar', trans('admin.avatar'))->rules('required');`
html内容如下
`<input type="file" class="avatar" name="avatar" required="1" data-initial-preview="http://127.0.0.1:8000/vendor/laravel-admin/AdminLTE/dist/img/user2-160x160.jpg" data-initial-caption="user2-160x160.jpg" id="1556473119408_67">`
所以我在render的时候存在原始数据的情况下清除了required="1" 属性。