### PR TITLE
fix a 'ide report errors' error

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -53,7 +53,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @method Field\TimeRange      timeRange($start, $end, $label = '')
  * @method Field\Number         number($column, $label = '')
  * @method Field\Currency       currency($column, $label = '')
- * @method Field\HasMany        hasMany($relationName, $callback)
+ * @method Field\HasMany        hasMany($relationName, $label = '', $callback)
  * @method Field\SwitchField    switch($column, $label = '')
  * @method Field\Display        display($column, $label = '')
  * @method Field\Rate           rate($column, $label = '')


### PR DESCRIPTION
use `$form->hasMany`, IDE will report errors：function call uses more parameters than the declaration.