### PR TITLE
Support icon in Content Header 

### DIFF
--- a/resources/views/content.blade.php
+++ b/resources/views/content.blade.php
@@ -3,6 +3,9 @@
 @section('content')
     <section class="content-header">
         <h1>
+            @if($headericon)
+            <i class="fa {{$headericon}}"></i>
+            @endif
             {{ $header ?: trans('admin.title') }}
             <small>{{ $description ?: trans('admin.description') }}</small>
         </h1>

--- a/resources/views/content.blade.php
+++ b/resources/views/content.blade.php
@@ -3,7 +3,7 @@
 @section('content')
     <section class="content-header">
         <h1>
-            @if($headericon)
+            @if(isset($headericon))
             <i class="fa {{$headericon}}" style="padding-right:4px;"></i>
             @endif
             {{ $header ?: trans('admin.title') }}

--- a/resources/views/content.blade.php
+++ b/resources/views/content.blade.php
@@ -4,7 +4,7 @@
     <section class="content-header">
         <h1>
             @if($headericon)
-            <i class="fa {{$headericon}}"></i>
+            <i class="fa {{$headericon}}" style="padding-right:4px;"></i>
             @endif
             {{ $header ?: trans('admin.title') }}
             <small>{{ $description ?: trans('admin.description') }}</small>

--- a/src/Layout/Content.php
+++ b/src/Layout/Content.php
@@ -275,6 +275,7 @@ class Content implements Renderable
     {
         $items = [
             'header'      => $this->header,
+            'headericon'  => $this->headericon,
             'description' => $this->description,
             'breadcrumb'  => $this->breadcrumb,
             'content'     => $this->build(),

--- a/src/Layout/Content.php
+++ b/src/Layout/Content.php
@@ -16,6 +16,13 @@ class Content implements Renderable
     protected $header = ' ';
 
     /**
+     * Content header icon.
+     *
+     * @var string
+     */
+    protected $headericon = null;
+
+    /**
      * Content description.
      *
      * @var string
@@ -56,6 +63,20 @@ class Content implements Renderable
     public function header($header = '')
     {
         $this->header = $header;
+
+        return $this;
+    }
+
+    /**
+     * Set header icon of content.
+     *
+     * @param string $header
+     *
+     * @return $this
+     */
+    public function headericon($headericon = null)
+    {
+        $this->headericon = $headericon;
 
         return $this;
     }


### PR DESCRIPTION
Support header icon.

Usage:

~~~
$content->headericon('fa-home');
~~~

Sample:
![image](https://user-images.githubusercontent.com/8457265/57269073-f81a0f80-70c0-11e9-8df2-69a22d5b38d3.png)
![image](https://user-images.githubusercontent.com/8457265/57269342-0b79aa80-70c2-11e9-98a4-947f2fcb1ee4.png)

