### PR TITLE
dynamic css/js surport for minify

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -335,6 +335,13 @@ class Admin
         self::css($assets['css']);
         self::js($assets['js']);
 
+        if (!app()->runningInConsole() && config('admin.minify_assets') && file_exists(public_path(static::$manifest))) {
+            self::$css = [];
+            self::$js = [];
+            $skin = config('admin.skin', 'skin-blue-light');
+            self::css("vendor/laravel-admin/AdminLTE/dist/css/skins/{$skin}.min.css");
+        }
+
         $this->fireBootedCallbacks();
     }
 

--- a/src/Console/MinifyCommand.php
+++ b/src/Console/MinifyCommand.php
@@ -77,7 +77,7 @@ class MinifyCommand extends Command
 
     protected function minifyCSS()
     {
-        $css = collect(array_merge(Admin::$css, Admin::baseCss()))
+        $css = collect(array_merge(Admin::$css, Admin::$baseCss))
             ->unique()->map(function ($css) {
                 if (url()->isValidUrl($css)) {
                     $this->assets['css'][] = $css;

--- a/src/Traits/HasAssets.php
+++ b/src/Traits/HasAssets.php
@@ -92,8 +92,12 @@ trait HasAssets
             return self::$css = array_merge(self::$css, (array) $css);
         }
 
-        if (!$css = static::getMinifiedCss()) {
+        $css = static::getMinifiedCss();
+
+        if (!$css) {
             $css = array_merge(static::$css, static::baseCss());
+        } else {
+            $css = array_merge($css, self::$css);
         }
 
         $css = array_filter(array_unique($css));
@@ -132,8 +136,12 @@ trait HasAssets
             return self::$js = array_merge(self::$js, (array) $js);
         }
 
-        if (!$js = static::getMinifiedJs()) {
+        $js = static::getMinifiedJs();
+
+        if (!$js) {
             $js = array_merge(static::baseJs(), static::$js);
+        } else {
+            $js = array_merge($js, self::$js);
         }
 
         $js = array_filter(array_unique($js));


### PR DESCRIPTION
Console环境和Web环境都是通过Admin::bootstrap()收集 js和css(理论上两次收集到的东西是相同的)。
可以在Web环境Admin::bootstrap()后清空 Admin::$css和 Admin::$js，因为这些资源已经被压缩了。
在View输出如果Admin::$js不为空，说明里面有后面加进去的js。