### PR TITLE
fix bug #3298 使用 admin域名，将prefix 设置为“/”，对非超级管理员进入“/”页面提示无权限

### DIFF
--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -42,7 +42,7 @@ class Permission extends Model
      *
      * @return BelongsToMany
      */
-    public function roles() : BelongsToMany
+    public function roles(): BelongsToMany
     {
         $pivotTable = config('admin.database.role_permissions_table');
 
@@ -58,7 +58,7 @@ class Permission extends Model
      *
      * @return bool
      */
-    public function shouldPassThrough(Request $request) : bool
+    public function shouldPassThrough(Request $request): bool
     {
         if (empty($this->http_method) && empty($this->http_path)) {
             return true;
@@ -67,7 +67,7 @@ class Permission extends Model
         $method = $this->http_method;
 
         $matches = array_map(function ($path) use ($method) {
-            $path = trim(config('admin.route.prefix'), '/').$path;
+            $path = trim(config('admin.route.prefix'), '/') . $path;
 
             if (Str::contains($path, ':')) {
                 list($method, $path) = explode(':', $path);
@@ -101,15 +101,15 @@ class Permission extends Model
     /**
      * If a request match the specific HTTP method and path.
      *
-     * @param array   $match
+     * @param array $match
      * @param Request $request
      *
      * @return bool
      */
-    protected function matchRequest(array $match, Request $request) : bool
+    protected function matchRequest(array $match, Request $request): bool
     {
         // if not "/"， trim
-        if(!$request->is('/')){
+        if (!$request->is('/')) {
             $match['path'] = trim($match['path'], '/');
         }
 

--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -109,7 +109,7 @@ class Permission extends Model
     protected function matchRequest(array $match, Request $request) : bool
     {
         // if not "/"， trim
-        if(!$request->is("/")){
+        if(!$request->is('/')){
             $match['path'] = trim($match['path'], '/');
         }
 

--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -108,7 +108,16 @@ class Permission extends Model
      */
     protected function matchRequest(array $match, Request $request) : bool
     {
-        if (!$request->is(trim($match['path'], '/'))) {
+        // if not "/"， trim
+        if(!$request->is("/")){
+            $match['path'] = trim($match['path'], '/');
+        }
+
+        if (!$request->is($match['path'])) {
+            return false;
+        }
+
+        if (!$request->is($match['path'])) {
             return false;
         }
 


### PR DESCRIPTION
Laravel Version: 5.7
PHP Version:7.2
Laravel-admin: 1.6.14

Description:

我是用了 admin.domain.com， prefix 设置为“/“ , 的情况下，设置子权限管理员，当子权限管理员进入home页面 “/” 的时候，提示无权限。