### PR TITLE
fix router namespace

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -290,7 +290,7 @@ class Admin
         app('router')->group($attributes, function ($router) {
 
             /* @var \Illuminate\Support\Facades\Route $router */
-            $router->namespace('Encore\Admin\Controllers')->group(function ($router) {
+            $router->namespace('\Encore\Admin\Controllers')->group(function ($router) {
 
                 /* @var \Illuminate\Routing\Router $router */
                 $router->resource('auth/users', 'UserController')->names('admin.auth.users');


### PR DESCRIPTION
当自定义 Admin Controller 目录时，会出现拼接错误