### PR TITLE
support setting ColunmSelector by default colunms

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -64,6 +64,13 @@ class Grid
     public $columnNames = [];
 
     /**
+     * Default columns be shown
+     *
+     * @var array
+     */
+    public $columnShownNames = [];
+
+    /**
      * Grid builder.
      *
      * @var \Closure
@@ -343,7 +350,12 @@ class Grid
      */
     public function visibleColumns()
     {
-        $visible = array_filter(explode(',', request(Tools\ColumnSelector::SELECT_COLUMN_NAME)));
+        $querySelections = array_filter(explode(',', request(Tools\ColumnSelector::SELECT_COLUMN_NAME)));
+        if ( count($querySelections) > 0) {
+            $visible = $querySelections;
+        } else {
+            $visible = $this->columnShownNames;
+        }
 
         if (empty($visible)) {
             return $this->columns;
@@ -363,7 +375,12 @@ class Grid
      */
     public function visibleColumnNames()
     {
-        $visible = array_filter(explode(',', request(Tools\ColumnSelector::SELECT_COLUMN_NAME)));
+        $querySelections = array_filter(explode(',', request(Tools\ColumnSelector::SELECT_COLUMN_NAME)));
+        if ( count($querySelections) > 0) {
+            $visible = $querySelections;
+        } else {
+            $visible = $this->columnShownNames;
+        }
 
         if (empty($visible)) {
             return $this->columnNames;
@@ -810,7 +827,21 @@ class Grid
      */
     public function renderColumnSelector()
     {
-        return (new Grid\Tools\ColumnSelector($this))->render();
+        $columnSelector = new Grid\Tools\ColumnSelector($this);
+        $columnSelector->columnShownNames = $this->columnShownNames;
+        return $columnSelector->render();
+    }
+
+    /**
+     * Setting default shown columns on grid.
+     *
+     * @param array $columns
+     * @return array
+     */
+    public function selectColumns($columns = [])
+    {
+        $this->columnShownNames = $columns;
+        return $this->columnShownNames;
     }
 
     /**

--- a/src/Grid/Tools/ColumnSelector.php
+++ b/src/Grid/Tools/ColumnSelector.php
@@ -15,6 +15,8 @@ class ColumnSelector extends AbstractTool
      */
     protected $grid;
 
+    public $columnShownNames = [];
+
     /**
      * Create a new Export button instance.
      *
@@ -35,7 +37,13 @@ class ColumnSelector extends AbstractTool
         if (!$this->grid->showColumnSelector()) {
             return '';
         }
-        $show = array_filter(explode(',', request(static::SELECT_COLUMN_NAME)));
+
+        $querySelections = array_filter(explode(',', request(static::SELECT_COLUMN_NAME)));
+        if ( count($querySelections) > 0) {
+            $show = $querySelections;
+        } else {
+            $show = $this->columnShownNames;
+        }
 
         $columns = $this->getGridColumns();
 


### PR DESCRIPTION
类似于我在控制器的Grid里
$grid->name('姓名');
$grid->age('年龄');
$grid->gender('性别');
$grid->selectColumns(['name','gender']);

然后只这么定义以后默认显示姓名和性别，年龄需要在菜单里自行勾选