### PR TITLE
Add `showCancel` option to setupDefaultOption of UploadField trait

### DIFF
--- a/src/Form/Field/UploadField.php
+++ b/src/Form/Field/UploadField.php
@@ -92,6 +92,7 @@ trait UploadField
             'cancelLabel'          => trans('admin.cancel'),
             'showRemove'           => false,
             'showUpload'           => false,
+            'showCancel'           => false,
             'dropZoneEnabled'      => false,
             'deleteExtraData'      => [
                 $this->formatName($this->column) => static::FILE_DELETE_FLAG,


### PR DESCRIPTION
The file upload form had a `Cancel` button displayed to the left of the `Browse` button(bootstrap-fileinput@4.5.2).
But this `Cancel` button does not work.
In previous versions the `Cancel` button was not displayed.
So I added an option to hide the `Cancel` button by default.

[Bootstrap File Input Options - showCancel](http://plugins.krajee.com/file-input/plugin-options#showCancel)

