### PR TITLE
自定义分页参数，可用于一个页面多个分页例子

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -444,11 +444,11 @@ class Grid
      *
      * @return void
      */
-    public function paginate($perPage = 20)
+    public function paginate($perPage = 20, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $this->perPage = $perPage;
 
-        $this->model()->setPerPage($perPage);
+        $this->model()->setPerPage($perPage, $columns, $pageName, $page);
     }
 
     /**


### PR DESCRIPTION
自定义分页参数，可用于一个页面多个分页例子；

还可以自定义字段名称,，如：
$grid->paginate(20, [DB::raw('name as newName')], 'newPage');