### PR TITLE
feat(resources): flash message 增加对 Laravel 表单验证错误的支持

### DIFF
--- a/resources/views/partials/alerts.blade.php
+++ b/resources/views/partials/alerts.blade.php
@@ -14,6 +14,15 @@
         @endforeach
       </div>
     @endif
+    @if ($errors->hasBag('default'))
+      <div class="alert alert-warning alert-dismissable">
+
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+        @foreach($errors->getBag("default")->toArray() as $message)
+            <p>{!!  \Illuminate\Support\Arr::get($message, 0) !!}</p>
+        @endforeach
+      </div>
+    @endif
 @endif
 
 @if($success = session()->get('success'))


### PR DESCRIPTION
在使用表单验证时，如果验证失败，就会抛出异常，并自动将对应的错误响应返回给用户。在不使用 ajax 作为典型的 HTTP 请求的情况下，会生成一个重定向响应，此时 MessageBag 中包含明为 default 的信息