### PR TITLE
 修复在nginx二级目录反向代理下的资源路径404以及页内url构建错误的的BUG

### DIFF
--- a/config/admin.php
+++ b/config/admin.php
@@ -367,4 +367,6 @@ return [
     'extensions' => [
 
     ],
+
+    'base_path' => '',
 ];

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -82,7 +82,10 @@ class AuthController extends Controller
 
         $request->session()->invalidate();
 
-        return redirect(config('admin.route.prefix'));
+        $basePath = trim(config('admin.base_path'), '/').'/';
+        $basePath = ($basePath == '/') ? '' : $basePath;
+
+        return redirect($basePath.config('admin.route.prefix'));
     }
 
     /**
@@ -176,7 +179,10 @@ class AuthController extends Controller
             return $this->redirectTo();
         }
 
-        return property_exists($this, 'redirectTo') ? $this->redirectTo : config('admin.route.prefix');
+        $basePath = trim(config('admin.base_path'), '/').'/';
+        $basePath = ($basePath == '/') ? '' : $basePath;
+
+        return property_exists($this, 'redirectTo') ? $this->redirectTo : ($basePath.config('admin.route.prefix'));
     }
 
     /**
@@ -192,7 +198,7 @@ class AuthController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->intended($this->redirectPath());
+        return redirect()->to($this->redirectPath());
     }
 
     /**

--- a/src/Form.php
+++ b/src/Form.php
@@ -1384,13 +1384,19 @@ class Form implements Renderable
      */
     public function resource($slice = -2)
     {
-        $segments = explode('/', trim(app('request')->getUri(), '/'));
+        $segments = explode('/', trim(app('request')->path(), '/'));
 
         if ($slice != 0) {
             $segments = array_slice($segments, 0, $slice);
         }
 
-        return implode('/', $segments);
+        $basePath = trim(config('admin.base_path'), '/');
+
+        if ($basePath != '') {
+            array_unshift($segments, $basePath);
+        }
+
+        return '/'.implode('/', $segments);
     }
 
     /**

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -779,7 +779,10 @@ class Grid
             return $this->resourcePath;
         }
 
-        return app('request')->getPathInfo();
+        $basePath = '/'.trim(config('admin.base_path'), '/');
+        $basePath = ($basePath == '/') ? '' : $basePath;
+
+        return $basePath.app('request')->getPathInfo();
     }
 
     /**

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -608,9 +608,12 @@ class Filter implements Renderable
 
         $question = $request->getBaseUrl().$request->getPathInfo() == '/' ? '/?' : '?';
 
-        return count($request->query()) > 0
-            ? $request->url().$question.http_build_query($query)
-            : $request->fullUrl();
+        $basePath = '/'.trim(config('admin.base_path'), '/');
+        $basePath = ($basePath == '/') ? '' : $basePath;
+
+        return $request->getUriForPath($basePath.(count($request->query()) > 0
+            ? $request->getPathInfo().$question.http_build_query($query)
+            : $request->getPathInfo()));
     }
 
     /**

--- a/src/Grid/Tools.php
+++ b/src/Grid/Tools.php
@@ -80,6 +80,8 @@ class Tools implements Renderable
     /**
      * Disable filter button.
      *
+     * @param bool $disable
+     *
      * @return void
      */
     public function disableFilterButton(bool $disable = true)

--- a/src/Middleware/Authenticate.php
+++ b/src/Middleware/Authenticate.php
@@ -41,8 +41,9 @@ class Authenticate
         ]);
 
         return collect($excepts)
-            ->map('admin_base_path')
-            ->contains(function ($except) use ($request) {
+            ->map(function ($expect) {
+                return admin_base_path($expect, false);
+            })->contains(function ($except) use ($request) {
                 if ($except !== '/') {
                     $except = trim($except, '/');
                 }

--- a/src/Middleware/Pjax.php
+++ b/src/Middleware/Pjax.php
@@ -152,9 +152,12 @@ class Pjax
      */
     protected function setUriHeader(Response $response, Request $request)
     {
+        $basePath = '/'.trim(config('admin.base_path'), '/');
+        $basePath = ($basePath == '/') ? '' : $basePath;
+
         $response->header(
             'X-PJAX-URL',
-            $request->getRequestUri()
+            $basePath.$request->getRequestUri()
         );
     }
 }

--- a/src/Show.php
+++ b/src/Show.php
@@ -316,7 +316,10 @@ class Show implements Renderable
     public function getResourcePath()
     {
         if (empty($this->resource)) {
-            $path = request()->path();
+            $basePath = trim(config('admin.base_path'), '/').'/';
+            $basePath = ($basePath == '/') ? '' : $basePath;
+
+            $path = $basePath.request()->path();
 
             $segments = explode('/', $path);
             array_pop($segments);

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -7,6 +7,9 @@ use Encore\Admin\Tree\Tools;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property  $path
+ */
 class Tree implements Renderable
 {
     /**
@@ -85,7 +88,10 @@ class Tree implements Renderable
     {
         $this->model = $model;
 
-        $this->path = app('request')->getPathInfo();
+        $basePath = '/'.trim(config('admin.base_path'), '/');
+        $basePath = ($basePath == '/') ? '' : $basePath;
+
+        $this->path = $basePath.app('request')->getPathInfo();
         $this->elementId .= uniqid();
 
         $this->setupTools();

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -44,22 +44,24 @@ if (!function_exists('admin_base_path')) {
      * Get admin url.
      *
      * @param string $path
+     * @param bool   $basePathFlag
      *
      * @return string
      */
-    function admin_base_path($path = '')
+    function admin_base_path($path = '', $basePathFlag = true)
     {
         $prefix = '/'.trim(config('admin.route.prefix'), '/');
-
         $prefix = ($prefix == '/') ? '' : $prefix;
 
-        $path = trim($path, '/');
+        $path = '/'.trim($path, '/');
+        $path = ($path == '/') ? '' : $path;
 
-        if (is_null($path) || strlen($path) == 0) {
-            return $prefix ?: '/';
-        }
+        $basePath = '/'.trim(config('admin.base_path'), '/');
+        $basePath = ($basePath == '/') ? '' : $basePath;
 
-        return $prefix.'/'.$path;
+        $requestPath = ($basePathFlag !== false ? $basePath : '').$prefix.$path;
+
+        return ($requestPath == '/') ? '' : $requestPath;
     }
 }
 
@@ -148,6 +150,11 @@ if (!function_exists('admin_asset')) {
      */
     function admin_asset($path)
     {
+        $basePath = '/'.trim(config('admin.base_path'), '/');
+        $basePath = ($basePath == '/') ? '' : $basePath;
+
+        $path = $basePath.'/'.trim($path, '/');
+
         return (config('admin.https') || config('admin.secure')) ? secure_asset($path) : asset($path);
     }
 }


### PR DESCRIPTION
解决方案是在 config/admin 下添加一个配置选项 base_path，如果是通过 {host}/laravel/admin 代理 {host:8000}/admin 只需要将 base_path 设置为 laravel 即可

Fixes #3319 