### PR TITLE
leave template to check batch actions empty

### DIFF
--- a/resources/views/grid/batch-actions.blade.php
+++ b/resources/views/grid/batch-actions.blade.php
@@ -7,10 +7,12 @@
         <span class="caret"></span>
         <span class="sr-only">Toggle Dropdown</span>
     </button>
+    @if(!$actions->isEmpty())
     <ul class="dropdown-menu" role="menu">
         @foreach($actions as $action)
             <li><a href="#" class="{{ $action->getElementClass(false) }}">{!! $action->render() !!} </a></li>
         @endforeach
     </ul>
+    @endif
 </div>
 @endif

--- a/src/Grid/Tools/BatchActions.php
+++ b/src/Grid/Tools/BatchActions.php
@@ -170,10 +170,6 @@ EOT;
             $this->actions->shift();
         }
 
-        if ($this->actions->isEmpty()) {
-            return '';
-        }
-
         $this->setUpScripts();
 
         $data = [


### PR DESCRIPTION
批量菜单判断是否为空的逻辑，留在模板里来判断，针对想显示选中的几行，但不想有批量操作情况。目前如果$batch->disableDelete();全选那里会出现一个没有样式、非常难看的checkbox