### PR TITLE
fix expand

### DIFF
--- a/src/Grid/Displayers/Expand.php
+++ b/src/Grid/Displayers/Expand.php
@@ -6,21 +6,25 @@ use Encore\Admin\Admin;
 
 class Expand extends AbstractDisplayer
 {
+    private $uniqueKey;
+
     public function display($callback = null)
     {
         $callback = $callback->bindTo($this->row);
 
         $html = call_user_func_array($callback, [$this->row]);
 
+        $key = $this->getKey();
+
+        $this->uniqueKey = $key . '-' . $this->column->getName();
+
         $this->setupScript();
 
-        $key = $this->column->getName().'-'.$this->getKey();
-
         return <<<EOT
-<span class="grid-expand" data-inserted="0" data-key="{$key}" data-toggle="collapse" data-target="#grid-collapse-{$key}">
+<span class="grid-expand-{$this->uniqueKey}" data-inserted="0" data-key="{$key}" data-toggle="collapse" data-target="#grid-collapse-{$key}">
    <a href="javascript:void(0)"><i class="fa fa-angle-double-down"></i>&nbsp;&nbsp;{$this->value}</a>
 </span>
-<template class="grid-expand-{$key}">
+<template class="grid-expand-{$this->uniqueKey}">
     <div id="grid-collapse-{$key}" class="collapse">
         <div  style="padding: 10px 10px 0 10px;">$html</div>
     </div>
@@ -30,15 +34,15 @@ EOT;
 
     protected function setupScript()
     {
-        $script = <<<'EOT'
+        $script = <<<EOT
 
-$('.grid-expand').on('click', function () {
+$('.grid-expand-{$this->uniqueKey}').on('click', function () {
     
     if ($(this).data('inserted') == '0') {
     
         var key = $(this).data('key');
         var row = $(this).closest('tr');
-        var html = $('template.grid-expand-'+key).html();
+        var html = $('template.grid-expand-'+"$this->uniqueKey").html();
 
         row.after("<tr style='background-color: #ecf0f5;'><td colspan='"+(row.find('td').length)+"' style='padding:0 !important; border:0;'>"+html+"</td></tr>");
 

--- a/src/Grid/Displayers/Expand.php
+++ b/src/Grid/Displayers/Expand.php
@@ -16,7 +16,7 @@ class Expand extends AbstractDisplayer
 
         $key = $this->getKey();
 
-        $this->uniqueKey = $key . '-' . $this->column->getName();
+        $this->uniqueKey = $key.'-'.$this->column->getName();
 
         $this->setupScript();
 


### PR DESCRIPTION
问题:
当一个grid中写了多个expand就出现点击expand按钮每次都显示的第一个。
```php
       $grid->column('base', '基本信息')->expand(function () {
            $data = [
                '编号' => $this->base_extra['serial_number'],
                '系列' => $this->base_extra['series'],
                '性别' => $this->base_extra['gender'],
                '别名' => $this->base_extra['alias']
            ];
            return new Table([], $data);
        });


        $grid->column('movement', '机芯')->expand(function () {
            $data = [
                '编号' => $this->movement_extra['type'],
                '系列' => $this->movement_extra['model'],
                '性别' => $this->movement_extra['attachment'],
                '游丝' => $this->movement_extra['balance_spring'],
                '动力存储' => $this->movement_extra['power']
            ];

            return new Table([], $data);
        });
```
主要是之前使用的是第一列使用的key和第二列使用的key是一样的。需要改一下js的地方。