### PR TITLE
Update date and datetime on grid filter between

### DIFF
--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -295,9 +295,9 @@ abstract class AbstractFilter
      *
      * @return DateTime
      */
-    public function date()
+    public function date($options = [])
     {
-        return $this->datetime(['format' => 'YYYY-MM-DD']);
+        return $this->datetime($options+['format' => 'YYYY-MM-DD']);
     }
 
     /**

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -297,7 +297,7 @@ abstract class AbstractFilter
      */
     public function date($options = [])
     {
-        return $this->datetime($options+['format' => 'YYYY-MM-DD']);
+        return $this->datetime($options + ['format' => 'YYYY-MM-DD']);
     }
 
     /**

--- a/src/Grid/Filter/Between.php
+++ b/src/Grid/Filter/Between.php
@@ -105,7 +105,8 @@ class Between extends AbstractFilter
      */
     protected function setupDatetime($options = [])
     {
-        $endDay=$options['endDay']??false;unset($options['endDay']);
+        $endDay = $options['endDay'] ?? false;
+        unset($options['endDay']);
 
         $options['format'] = Arr::get($options, 'format', 'YYYY-MM-DD HH:mm:ss');
         $options['locale'] = Arr::get($options, 'locale', config('app.locale'));
@@ -113,8 +114,8 @@ class Between extends AbstractFilter
         $startOptions = json_encode($options);
         $endOptions = json_encode($options + ['useCurrent' => false]);
 
-        if($endDay){
-            $options['format']='YYYY-MM-DD 23:59:59';
+        if ($endDay) {
+            $options['format'] = 'YYYY-MM-DD 23:59:59';
             $endOptions = json_encode($options + ['useCurrent' => false]);
         }
 

--- a/src/Grid/Filter/Between.php
+++ b/src/Grid/Filter/Between.php
@@ -105,11 +105,18 @@ class Between extends AbstractFilter
      */
     protected function setupDatetime($options = [])
     {
+        $endDay=$options['endDay']??false;unset($options['endDay']);
+
         $options['format'] = Arr::get($options, 'format', 'YYYY-MM-DD HH:mm:ss');
         $options['locale'] = Arr::get($options, 'locale', config('app.locale'));
 
         $startOptions = json_encode($options);
         $endOptions = json_encode($options + ['useCurrent' => false]);
+
+        if($endDay){
+            $options['format']='YYYY-MM-DD 23:59:59';
+            $endOptions = json_encode($options + ['useCurrent' => false]);
+        }
 
         $script = <<<EOT
             $('#{$this->id['start']}').datetimepicker($startOptions);


### PR DESCRIPTION
```
$filter->column(1/2,function($filter){
                $filter->between('issued_date',localize('project_site.filter.form.register_date','Payroll Date'))->datetime(['endDay'=>true]);
});
```
Add and an option to trigger the end time of day for filter between with datetime().
![Screenshot from 2019-07-18 19-50-20](https://user-images.githubusercontent.com/769127/61458863-b39ad200-a995-11e9-89e8-395a26934733.png)
![Screenshot from 2019-07-18 19-49-27](https://user-images.githubusercontent.com/769127/61458872-b990b300-a995-11e9-90ee-4a92375ea4a9.png)

