### PR TITLE
修复创建数据验证错误信息的返回判断

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -463,7 +463,7 @@ class Form implements Renderable
      */
     protected function responseValidationError(MessageBag $message)
     {
-        if (\request()->ajax()) {
+        if (\request()->ajax() && !\request()->pjax()) {
             return response()->json([
                 'status'     => false,
                 'validation' => $message,


### PR DESCRIPTION
现在表单提交创建后的数据验证错误返回只判断了是否ajax，应该增加判断不是pjax。不然正常的表单创建只会输出一段JSON错误了