### PR TITLE
防止表单重复提交

### DIFF
--- a/resources/views/form/footer.blade.php
+++ b/resources/views/form/footer.blade.php
@@ -9,7 +9,7 @@
 
         @if(in_array('submit', $buttons))
         <div class="btn-group pull-right">
-            <button type="submit" class="btn btn-primary">{{ trans('admin.submit') }}</button>
+            <button type="submit" class="btn btn-primary" onclick="this.form.submit();this.disabled = true;">{{ trans('admin.submit') }}</button>
         </div>
 
         @foreach($submit_redirects as $value => $redirect)


### PR DESCRIPTION
对于一些很简单的表单，在新增页面如果快速点击会导致多次提交，这个小改动使得提交完成之后提交按钮不可点击，具体代码抄自 https://stackoverflow.com/a/52695077/3122424