### PR TITLE
解决手机端标题栏错误显示为两行遮挡正确内容的问题

### DIFF
--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -15,9 +15,7 @@
         <a href="#" class="sidebar-toggle" data-toggle="offcanvas" role="button">
             <span class="sr-only">Toggle navigation</span>
         </a>
-        <ul class="nav navbar-nav">
         {!! Admin::getNavbar()->render('left') !!}
-        </ul>
 
         <!-- Navbar Right Menu -->
         <div class="navbar-custom-menu">


### PR DESCRIPTION
解决手机端标题栏错误显示为两行遮挡正确内容的问题
修改之前:
![before](http://wx4.sinaimg.cn/mw690/005L8sEhgy1g5htvkfya0j30cw0kxwfb.jpg)

修改之后:
![after](http://wx1.sinaimg.cn/mw690/005L8sEhgy1g5htvioowmj30cw0l80tl.jpg)