### PR TITLE
修复手机端标题栏显示两行的问题,并兼容导航栏的Left Right设置

### DIFF
--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -15,9 +15,7 @@
         <a href="#" class="sidebar-toggle" data-toggle="offcanvas" role="button">
             <span class="sr-only">Toggle navigation</span>
         </a>
-        <ul class="nav navbar-nav">
         {!! Admin::getNavbar()->render('left') !!}
-        </ul>
 
         <!-- Navbar Right Menu -->
         <div class="navbar-custom-menu">


### PR DESCRIPTION
修复手机端标题栏显示两行的问题,并兼容导航栏的Left Right设置,
before:
![before](http://wx2.sinaimg.cn/mw690/005L8sEhgy1g5izn9td9bj30dj0l83z1.jpg)

after:
![after](http://wx1.sinaimg.cn/mw690/005L8sEhgy1g5izlipxdpj30dl0li3ze.jpg)