### PR TITLE
Fixed: use the last query value

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -525,7 +525,7 @@ class Model
      */
     protected function findQueryByMethod($method)
     {
-        return $this->queries->first(function ($query) use ($method) {
+        return $this->queries->last(function ($query) use ($method) {
             return $query['method'] == $method;
         });
     }


### PR DESCRIPTION
比如下面代码：
```php
Grid::init(function (Grid $grid) {
    $grid->paginate(20);
});

// 控制器里面
$grid->paginate(10);
```

控制器里面的分页方法，无法生效。永远取得是第一个值，应该使用最后设置的值