### PR TITLE
Grid: Copyable Displayer Improvement

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -104,4 +104,6 @@ return [
     'prev'                   => 'Prev',
     'next'                   => 'Next',
     'quick_create'           => 'Quick create',
+    'copy'                   => 'Copy',
+    'copied'                 => 'Copied!'
 ];

--- a/resources/lang/pt-BR/admin.php
+++ b/resources/lang/pt-BR/admin.php
@@ -99,4 +99,6 @@ return [
         'filter_placeholder' => 'Filtrar',
     ],
     'menu_titles'           => [],
+    'copy'                  => 'Copiar',
+    'copied'                => 'Copiado!'
 ];

--- a/resources/lang/pt/admin.php
+++ b/resources/lang/pt/admin.php
@@ -99,4 +99,6 @@ return [
         'filter_placeholder' => 'Filtrar',
     ],
     'menu_titles'           => [],
+    'copy'                  => 'Copiar',
+    'copied'                => 'Copiado!'
 ];

--- a/src/Grid/Displayers/Copyable.php
+++ b/src/Grid/Displayers/Copyable.php
@@ -14,8 +14,9 @@ class Copyable extends AbstractDisplayer
     protected function addScript()
     {
         $script = <<<SCRIPT
-$('#{$this->grid->tableID}').on('click','.grid-column-copyable',(function (e) {
-    var content = $(this).data('content');
+$('#{$this->grid->tableID}').on('click','.grid-column-copyable', function (e) {
+    var copyLink = $(this);
+    var content = copyLink.data('content');
     
     var temp = $('<input>');
     
@@ -24,8 +25,26 @@ $('#{$this->grid->tableID}').on('click','.grid-column-copyable',(function (e) {
     document.execCommand("copy");
     temp.remove();
     
-    $(this).tooltip('show');
-}));
+    copyLink.focusout()
+        .attr('title', copyLink.data('copied-title'))
+        .tooltip('fixTitle')
+        .tooltip('show')
+        .on('mouseleave focusout', function() {
+            copyLink.attr('title', copyLink.data('copy-title'))
+                .tooltip('fixTitle');
+        });      
+});
+
+$('#{$this->grid->tableID} .grid-column-copyable')
+    .tooltip({
+        trigger: 'manual'
+    })
+    .mouseenter(function() {
+        $(this).tooltip('show');
+    })
+    .mouseleave(function(e) {
+        $(this).tooltip('hide');
+    });
 SCRIPT;
 
         Admin::script($script);
@@ -37,8 +56,11 @@ SCRIPT;
 
         $content = $this->getColumn()->getOriginal();
 
+        $copy   = __('admin.copy');
+        $copied = __('admin.copied');
+
         return <<<HTML
-<a href="javascript:void(0);" class="grid-column-copyable text-muted" data-content="{$content}" title="Copied!" data-placement="bottom">
+<a href="javascript:void(0);" class="grid-column-copyable text-muted" data-content="{$content}" data-placement="bottom" title="{$copy}" data-copy-title="{$copy}" data-copied-title="{$copied}">
     <i class="fa fa-copy"></i>
 </a>&nbsp;{$this->getValue()}
 HTML;


### PR DESCRIPTION
The tooltip only showed up after click, now it appears before and after click, showing "Copy" and "Copied!".

Before
![Screen Recording 2019-08-06 at 01 52 PM](https://user-images.githubusercontent.com/3445672/62541682-29d27c00-b852-11e9-8ac7-789deea487f2.gif)

After
![Screen Recording 2019-08-06 at 01 53 PM](https://user-images.githubusercontent.com/3445672/62541698-2f2fc680-b852-11e9-89a2-00a3b7979f98.gif)
