### PR TITLE
Bug/form set width

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -280,6 +280,9 @@ class Form implements Renderable
     {
         $field->setForm($this);
 
+        $width=$this->builder->getWidth();
+        $field->setWidth($width["field"],$width['label']);
+
         $this->builder->fields()->push($field);
         $this->layout->addField($field);
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -280,8 +280,8 @@ class Form implements Renderable
     {
         $field->setForm($this);
 
-        $width=$this->builder->getWidth();
-        $field->setWidth($width["field"],$width['label']);
+        $width = $this->builder->getWidth();
+        $field->setWidth($width['field'], $width['label']);
 
         $this->builder->fields()->push($field);
         $this->layout->addField($field);

--- a/src/Grid/Displayers/Label.php
+++ b/src/Grid/Displayers/Label.php
@@ -15,7 +15,7 @@ class Label extends AbstractDisplayer
 
         return collect((array) $this->value)->map(function ($item) use ($style) {
             if (is_array($style)) {
-                if(is_string($this->getColumn()->getOriginal()) || is_int($this->getColumn()->getOriginal())) {
+                if (is_string($this->getColumn()->getOriginal()) || is_int($this->getColumn()->getOriginal())) {
                     $style = Arr::get($style, $this->getColumn()->getOriginal(), 'success');
                 } else {
                     $style = Arr::get($style, $item, 'success');


### PR DESCRIPTION

先调用$form->setWidth(),后调用$form->text()时,宽度设置未生效.

使用场景:
先设置全部条目的默认值为:`        $form->setWidth(9,3);`,
然后单独设置图片的width:
```
            $form->html(function ($form) {
                $value = $form->model()->image;
                return '<a target="_blank" href="'.$value.'">
                    <img src="'.$value.'" style="height: 400px"/></a>';
            })->setWidth(12, 0);
```

![image](https://user-images.githubusercontent.com/9959927/63020406-a1e31680-bed0-11e9-9990-b4e127dd995c.png)

