### PR TITLE
在使用关系列时grid modal不能正常工作

### DIFF
--- a/src/Grid/Displayers/Modal.php
+++ b/src/Grid/Displayers/Modal.php
@@ -16,7 +16,7 @@ class Modal extends AbstractDisplayer
 
         $html = call_user_func_array($callback, [$this->row]);
 
-        $key = $this->getKey().'-'.$this->getColumn()->getName();
+        $key = $this->getKey().'-'.str_replace('.','_',$this->getColumn()->getName());;
 
         return <<<EOT
 <span class="grid-expand" data-toggle="modal" data-target="#grid-modal-{$key}">

--- a/src/Grid/Displayers/Modal.php
+++ b/src/Grid/Displayers/Modal.php
@@ -16,7 +16,7 @@ class Modal extends AbstractDisplayer
 
         $html = call_user_func_array($callback, [$this->row]);
 
-        $key = $this->getKey().'-'.str_replace('.','_',$this->getColumn()->getName());;
+        $key = $this->getKey().'-'.str_replace('.','_',$this->getColumn()->getName());
 
         return <<<EOT
 <span class="grid-expand" data-toggle="modal" data-target="#grid-modal-{$key}">


### PR DESCRIPTION
由于使用modal时，标签ID存在"."符号，无法根据ID找到元素，导致modal插件失效。