### PR TITLE
Bug fix for row style

### DIFF
--- a/src/Grid/Row.php
+++ b/src/Grid/Row.php
@@ -120,7 +120,7 @@ class Row
     public function style($style)
     {
         if (is_array($style)) {
-            $style = implode('', array_map(function ($key, $val) {
+            $style = implode(';', array_map(function ($key, $val) {
                 return "$key:$val";
             }, array_keys($style), array_values($style)));
         }


### PR DESCRIPTION
如果增加多个styles时候，会出现没有css分隔符的情况导致css失效。