### PR TITLE
fixbug Parameter #1 $builder of method Encore\Admin\Grid\Column::filter() expects null, array<int, string> given.

### DIFF
--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -467,7 +467,7 @@ class Column
     /**
      * Set column filter.
      *
-     * @param null $builder
+     * @param mixed|null $builder
      *
      * @return $this
      */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6964962/64327534-76020f00-cffe-11e9-8bb2-1ae41835d319.png)
