### PR TITLE
Scope separator

### DIFF
--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -423,7 +423,7 @@ class Filter implements Renderable
     }
 
     /**
-     * Add separator in filter scope
+     * Add separator in filter scope.
      *
      * @return mixed
      */

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -423,6 +423,16 @@ class Filter implements Renderable
     }
 
     /**
+     * Add separator in filter scope
+     *
+     * @return mixed
+     */
+    public function scopeSeparator()
+    {
+        return $this->scope('separator');
+    }
+
+    /**
      * Get all filter scopes.
      *
      * @return Collection

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -429,7 +429,7 @@ class Filter implements Renderable
      */
     public function scopeSeparator()
     {
-        return $this->scope('separator');
+        return $this->scope(Scope::SCOPE_SEPARATOR);
     }
 
     /**

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -429,7 +429,7 @@ class Filter implements Renderable
      */
     public function scopeSeparator()
     {
-        return $this->scope(Scope::SCOPE_SEPARATOR);
+        return $this->scope(Scope::SEPARATOR);
     }
 
     /**

--- a/src/Grid/Filter/Scope.php
+++ b/src/Grid/Filter/Scope.php
@@ -66,6 +66,10 @@ class Scope implements Renderable
      */
     public function render()
     {
+        if ($this->key == 'separator') {
+            return '<li role="separator" class="divider"></li>';
+        }
+
         $url = request()->fullUrlWithQuery([static::QUERY_NAME => $this->key]);
 
         return "<li><a href=\"{$url}\">{$this->label}</a></li>";

--- a/src/Grid/Filter/Scope.php
+++ b/src/Grid/Filter/Scope.php
@@ -9,7 +9,8 @@ use Illuminate\Support\Str;
 class Scope implements Renderable
 {
     const QUERY_NAME = '_scope_';
-
+    const SCOPE_SEPARATOR = '_separator_';
+    
     /**
      * @var string
      */
@@ -66,7 +67,7 @@ class Scope implements Renderable
      */
     public function render()
     {
-        if ($this->key == 'separator') {
+        if ($this->key == static::SCOPE_SEPARATOR) {
             return '<li role="separator" class="divider"></li>';
         }
 

--- a/src/Grid/Filter/Scope.php
+++ b/src/Grid/Filter/Scope.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 class Scope implements Renderable
 {
     const QUERY_NAME = '_scope_';
-    const SCOPE_SEPARATOR = '_separator_';
+    const SEPARATOR = '_separator_';
 
     /**
      * @var string
@@ -67,7 +67,7 @@ class Scope implements Renderable
      */
     public function render()
     {
-        if ($this->key == static::SCOPE_SEPARATOR) {
+        if ($this->key == static::SEPARATOR) {
             return '<li role="separator" class="divider"></li>';
         }
 

--- a/src/Grid/Filter/Scope.php
+++ b/src/Grid/Filter/Scope.php
@@ -10,7 +10,7 @@ class Scope implements Renderable
 {
     const QUERY_NAME = '_scope_';
     const SCOPE_SEPARATOR = '_separator_';
-    
+
     /**
      * @var string
      */


### PR DESCRIPTION
### Add separator in scope filter

**Use:**
`$filter->scopeSeparator();`


**Example:**
```
$grid->filter(function ($filter) {
    $filter->scope('admins', 'Admins')->administrators();
    $filter->scope('managers', 'Managers')->managers();
    $filter->scope('operators', 'Operators')->operators();
    $filter->scopeSeparator();
    $filter->scope('actived', 'Active')->actived();
    $filter->scope('deactivated', 'Not active')->deactivated();
});
```
![ScopeSeparator](https://user-images.githubusercontent.com/51013959/65213053-44348200-daad-11e9-8362-350d2384675d.png)
