### PR TITLE
index.blade.php add a 1px top-padding space for ngprogress

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -37,7 +37,7 @@
 
     @include('admin::partials.sidebar')
 
-    <div class="content-wrapper" id="pjax-container">
+    <div class="content-wrapper" id="pjax-container" style="padding-top: 1px;">
         {!! Admin::style() !!}
         <div id="app">
         @yield('content')


### PR DESCRIPTION
add a 1px top-padding for ngprogress can fix the sm screen page reload

Before:
![螢幕快照 2019-09-21 上午11 48 23](https://user-images.githubusercontent.com/3434037/65371197-d1393000-dc93-11e9-8bfe-0b7be656f502.png)

After:
![螢幕快照 2019-09-21 下午5 20 27](https://user-images.githubusercontent.com/3434037/65371226-2ffea980-dc94-11e9-90bc-0c6605a1431b.png)
