### PR TITLE
fix checkbox bug: when its value is null,Checkbox will throw "array_f…

### DIFF
--- a/resources/views/form/checkbox.blade.php
+++ b/resources/views/form/checkbox.blade.php
@@ -20,7 +20,7 @@
             {!! $inline ? '<span class="icheck">' : '<div class="checkbox icheck">' !!}
 
                 <label @if($inline)class="checkbox-inline"@endif>
-                    <input type="checkbox" name="{{$name}}[]" value="{{$option}}" class="{{$class}}" {{ false !== array_search($option, array_filter(old($column, $value))) || ($value === null && in_array($option, $checked)) ?'checked':'' }} {!! $attributes !!} />&nbsp;{{$label}}&nbsp;&nbsp;
+                    <input type="checkbox" name="{{$name}}[]" value="{{$option}}" class="{{$class}}" {{ false !== array_search($option, array_filter(old($column, $value ?? []))) || ($value === null && in_array($option, $checked)) ?'checked':'' }} {!! $attributes !!} />&nbsp;{{$label}}&nbsp;&nbsp;
                 </label>
 
             {!! $inline ? '</span>' :  '</div>' !!}


### PR DESCRIPTION
fix checkbox bug: when its value is null,Checkbox will throw "array_filter() expects parameter 1 to be array, null given"

