### PR TITLE
No URL in middle breadcrumb

### DIFF
--- a/resources/views/content.blade.php
+++ b/resources/views/content.blade.php
@@ -21,12 +21,19 @@
                     </li>
                 @else
                 <li>
-                    <a href="{{ admin_url(\Illuminate\Support\Arr::get($item, 'url')) }}">
+                    @if (\Illuminate\Support\Arr::has($item, 'url'))
+                        <a href="{{ admin_url(\Illuminate\Support\Arr::get($item, 'url')) }}">
+                            @if (\Illuminate\Support\Arr::has($item, 'icon'))
+                                <i class="fa fa-{{ $item['icon'] }}"></i>
+                            @endif
+                            {{ $item['text'] }}
+                        </a>
+                    @else
                         @if (\Illuminate\Support\Arr::has($item, 'icon'))
                             <i class="fa fa-{{ $item['icon'] }}"></i>
                         @endif
                         {{ $item['text'] }}
-                    </a>
+                    @endif
                 </li>
                 @endif
             @endforeach


### PR DESCRIPTION
In some projects for segment URL not exists own page. In such cases, the breadcrumb links to the main page. Fixed.
![breadcrumb](https://user-images.githubusercontent.com/51013959/67137755-d1443580-f229-11e9-81f4-5c09650082dd.png)
