### PR TITLE
Tags in header and description content

### DIFF
--- a/resources/views/content.blade.php
+++ b/resources/views/content.blade.php
@@ -1,10 +1,10 @@
-@extends('admin::index', ['header' => $header])
+@extends('admin::index', ['header' => strip_tags($header)])
 
 @section('content')
     <section class="content-header">
         <h1>
-            {{ $header ?: trans('admin.title') }}
-            <small>{{ $description ?: trans('admin.description') }}</small>
+            {!! $header ?: trans('admin.title') !!}
+            <small>{!! $description ?: trans('admin.description') !!}</small>
         </h1>
 
         <!-- breadcrumb start -->


### PR DESCRIPTION
Allow the use of tags in the title and description of the content.

**Example**
```
return $content
    ->title("<span class='fa fa-{$report->icon}'></span> {$report->name}")
    ->description("for the period <b>{$report->fromdate}</b> to <b>{$report->tilldate}</b> (<span title='Report created time'>{$report->makedate}</span>)")
    ->breadcrumb(
        ['text' => 'Reports', 'icon' => 'copy'],
        ['text' => $report->name, 'icon' => $report->icon]
    )
    ->body($grid);
```
![TagsInHeaderContent](https://user-images.githubusercontent.com/51013959/67615905-b69a2f80-f7da-11e9-9f03-33fc14059668.png)
