### PR TITLE
修复新版本操作列无法使用图标模式的bug

### DIFF
--- a/src/Grid/Concerns/HasActions.php
+++ b/src/Grid/Concerns/HasActions.php
@@ -62,7 +62,7 @@ trait HasActions
      */
     public function setActionClass(string $actionClass)
     {
-        if (is_subclass_of($actionClass, Grid\Displayers\Actions::class)) {
+        if (is_subclass_of($actionClass, Grid\Displayers\Actions::class) || ($actionClass == Grid\Displayers\Actions::class)) {
             $this->actionsClass = $actionClass;
         }
 


### PR DESCRIPTION
新版本全局设置为右键或者下拉操作时，无法通过文档所述为单个 grid 自定义修改为 图标模式