### PR TITLE
Fixed the `Trying to access array offset on value of type null` error on php7.4

### DIFF
--- a/resources/views/form/daterange.blade.php
+++ b/resources/views/form/daterange.blade.php
@@ -10,14 +10,14 @@
             <div class="col-lg-6">
                 <div class="input-group">
                     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
-                    <input type="text" name="{{$name['start']}}" value="{{ old($column['start'], $value['start']) }}" class="form-control {{$class['start']}}" style="width: 150px" {!! $attributes !!} />
+                    <input type="text" name="{{$name['start']}}" value="{{ old($column['start'], $value['start'] ?? null) }}" class="form-control {{$class['start']}}" style="width: 150px" {!! $attributes !!} />
                 </div>
             </div>
 
             <div class="col-lg-6">
                 <div class="input-group">
                     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
-                    <input type="text" name="{{$name['end']}}" value="{{ old($column['end'], $value['end']) }}" class="form-control {{$class['end']}}" style="width: 150px" {!! $attributes !!} />
+                    <input type="text" name="{{$name['end']}}" value="{{ old($column['end'], $value['end'] ?? null) }}" class="form-control {{$class['end']}}" style="width: 150px" {!! $attributes !!} />
                 </div>
             </div>
         </div>

--- a/resources/views/form/datetimerange.blade.php
+++ b/resources/views/form/datetimerange.blade.php
@@ -10,14 +10,14 @@
             <div class="col-lg-6">
                 <div class="input-group">
                     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
-                    <input type="text" name="{{$name['start']}}" value="{{ old($column['start'], $value['start']) }}" class="form-control {{$class['start']}}" style="width: 160px" {!! $attributes !!} />
+                    <input type="text" name="{{$name['start']}}" value="{{ old($column['start'], $value['start'] ?? null) }}" class="form-control {{$class['start']}}" style="width: 160px" {!! $attributes !!} />
                 </div>
             </div>
 
             <div class="col-lg-6">
                 <div class="input-group">
                     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
-                    <input type="text" name="{{$name['end']}}" value="{{ old($column['end'], $value['end']) }}" class="form-control {{$class['end']}}" style="width: 160px" {!! $attributes !!} />
+                    <input type="text" name="{{$name['end']}}" value="{{ old($column['end'], $value['end'] ?? null) }}" class="form-control {{$class['end']}}" style="width: 160px" {!! $attributes !!} />
                 </div>
             </div>
         </div>

--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -42,7 +42,7 @@ class DateRange extends Field
     public function value($value = null)
     {
         if (is_null($value)) {
-            if (is_null($this->value['start']) && is_null($this->value['end'])) {
+            if (!is_null($this->value) && is_null($this->value['start']) && is_null($this->value['end'])) {
                 return $this->getDefault();
             }
 


### PR DESCRIPTION
参见: https://twitter.com/nikita_ppv/status/1148931277216800769

PHP 7.4 will throw a notice for invalid array accesses like $null[0] or $int['bar']. Previously this silently returned null...