### PR TITLE
Add aggregation operation for total row: SUM, COUNT, AVG, MIN, MAX

### DIFF
--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -629,6 +629,76 @@ class Column
     }
 
     /**
+     * For total-row column used aggregation operation SUM.
+     *
+     * @param null $display
+     *
+     * @return $this
+     */
+    public function totalSum($display = null)
+    {
+        $this->grid->addTotalOperation($this->name, 'sum', $display);
+
+        return $this;
+    }
+
+    /**
+     * For total-row column used aggregation operation COUNT.
+     *
+     * @param null $display
+     *
+     * @return $this
+     */
+    public function totalCount($display = null)
+    {
+        $this->grid->addTotalOperation($this->name, 'count', $display);
+
+        return $this;
+    }
+
+    /**
+     * For total-row column used aggregation operation AVG.
+     *
+     * @param null $display
+     *
+     * @return $this
+     */
+    public function totalAvg($display = null)
+    {
+        $this->grid->addTotalOperation($this->name, 'avg', $display);
+
+        return $this;
+    }
+
+    /**
+     * For total-row column used aggregation operation MIN.
+     *
+     * @param null $display
+     *
+     * @return $this
+     */
+    public function totalMin($display = null)
+    {
+        $this->grid->addTotalOperation($this->name, 'min', $display);
+
+        return $this;
+    }
+
+    /**
+     * For total-row column used aggregation operation MAX.
+     *
+     * @param null $display
+     *
+     * @return $this
+     */
+    public function totalMax($display = null)
+    {
+        $this->grid->addTotalOperation($this->name, 'max', $display);
+
+        return $this;
+    }
+
+    /**
      * Convert file size to a human readable format like `100mb`.
      *
      * @return $this

--- a/src/Grid/Concerns/HasTotalRow.php
+++ b/src/Grid/Concerns/HasTotalRow.php
@@ -27,7 +27,7 @@ trait HasTotalRow
     {
         $this->totalRowColumns[$column] = $callback;
 
-        if ( !isset($this->totalRowOperations[$column]) ) {
+        if (!isset($this->totalRowOperations[$column])) {
             $this->addTotalOperation($column, 'sum');
         }
 
@@ -35,14 +35,14 @@ trait HasTotalRow
     }
 
     /**
-     * @param string  $column
-     * @param string  $operation
+     * @param string $column
+     * @param string $operation
      *
      * @return $this
      */
     public function addTotalOperation($column, $operation, $callback = null)
     {
-        if ( !is_null($callback) ) {
+        if (!is_null($callback)) {
             $this->totalRowColumns[$column] = $callback;
         }
 

--- a/src/Grid/Concerns/HasTotalRow.php
+++ b/src/Grid/Concerns/HasTotalRow.php
@@ -13,6 +13,11 @@ trait HasTotalRow
     protected $totalRowColumns = [];
 
     /**
+     * @var array
+     */
+    protected $totalRowOperations = [];
+
+    /**
      * @param string  $column
      * @param Closure $callback
      *
@@ -21,6 +26,27 @@ trait HasTotalRow
     public function addTotalRow($column, $callback)
     {
         $this->totalRowColumns[$column] = $callback;
+
+        if ( !isset($this->totalRowOperations[$column]) ) {
+            $this->addTotalOperation($column, 'sum');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string  $column
+     * @param string  $operation
+     *
+     * @return $this
+     */
+    public function addTotalOperation($column, $operation, $callback = null)
+    {
+        if ( !is_null($callback) ) {
+            $this->totalRowColumns[$column] = $callback;
+        }
+
+        $this->totalRowOperations[$column] = $operation;
 
         return $this;
     }
@@ -36,7 +62,7 @@ trait HasTotalRow
 
         $query = $this->model()->getQueryBuilder();
 
-        $totalRow = new TotalRow($query, $this->totalRowColumns);
+        $totalRow = new TotalRow($query, $this->totalRowColumns, $this->totalRowOperations);
 
         $totalRow->setGrid($this);
 

--- a/src/Grid/Tools/TotalRow.php
+++ b/src/Grid/Tools/TotalRow.php
@@ -20,6 +20,11 @@ class TotalRow extends AbstractTool
     protected $columns;
 
     /**
+     * @var array
+     */
+    protected $operations;
+
+    /**
      * @var Collection
      */
     protected $visibleColumns;
@@ -29,12 +34,15 @@ class TotalRow extends AbstractTool
      *
      * @param Builder $query
      * @param array   $columns
+     * @param array   $operations
      */
-    public function __construct($query, array $columns)
+    public function __construct($query, array $columns, array $operations)
     {
         $this->query = $query;
 
         $this->columns = $columns;
+
+        $this->operations = $operations;
     }
 
     /**
@@ -42,16 +50,17 @@ class TotalRow extends AbstractTool
      *
      * @param string $column
      * @param mixed  $display
+     * @param string $operation
      *
      * @return mixed
      */
-    protected function total($column, $display = null)
+    protected function total($column, $display = null, $operation = 'sum')
     {
         if (!is_callable($display) && !is_null($display)) {
             return $display;
         }
 
-        $sum = $this->query->sum($column);
+        $sum = $this->query->$operation($operation == 'count' ? '*' : $column);
 
         if (is_callable($display)) {
             return call_user_func($display, $sum);
@@ -93,7 +102,7 @@ class TotalRow extends AbstractTool
             $total = '';
 
             if (Arr::has($this->columns, $name)) {
-                $total = $this->total($name, Arr::get($this->columns, $name));
+                $total = $this->total($name, Arr::get($this->columns, $name), Arr::get($this->operations, $name));
             }
 
             return [


### PR DESCRIPTION
I suggest adding aggregate operations for total row: **SUM**, **COUNT**, **AVG**, **MIN**, **MAX**

Example use:
```
$grid->column('manager_name', 'Оператор')->totalRow('Всего:');
$grid->column('expand_orders', 'Заказы')->totalCount();
$grid->column('orders_all_sum', 'Сумма заказов')->totalSum();
$grid->column('orders_approved_avg', 'Cредний чек апрува')->totalAvg();
```
![2019-12-21_185356](https://user-images.githubusercontent.com/51013959/71311085-be660100-2424-11ea-8153-98dfc95b7d13.png)
