### PR TITLE
fix bug

### DIFF
--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -589,8 +589,14 @@ $('#has-many-{$this->column}').on('click', '.add', function () {
 });
 
 $('#has-many-{$this->column}').on('click', '.remove', function () {
-    $(this).closest('.has-many-{$this->column}-form').hide();
-    $(this).closest('.has-many-{$this->column}-form').find('.$removeClass').val(1);
+    var first_input_name = $(this).closest('.has-many-{$this->column}-form').find('input:first').attr('name');
+    if (first_input_name.match('{$this->column}\\\[new_')) {
+        $(this).closest('.has-many-{$this->column}-form').remove();
+    } else {
+        $(this).closest('.has-many-{$this->column}-form').hide();
+        $(this).closest('.has-many-{$this->column}-form').find('.$removeClass').val(1);
+        $(this).closest('.has-many-{$this->column}-form').find('input').removeAttr('required');
+    }
     return false;
 });
 


### PR DESCRIPTION
1. 如果form->hasMany里有required字段，然后点“移除”按钮，提交的时候会报错。因为“移除”按钮只是hide()，需要把hide()里的required去掉。
2. 如果该页面是create不是edit，hasMany的“移除”应该直接remove()掉，并不需要hide()和 修改_remove_ 操作。