### PR TITLE
Grid Switch Bug

### DIFF
--- a/src/Grid/Displayers/SwitchDisplay.php
+++ b/src/Grid/Displayers/SwitchDisplay.php
@@ -46,7 +46,7 @@ $('.$class').bootstrapSwitch({
     offColor: '{$this->states['off']['color']}',
     onSwitchChange: function(event, state){
 
-        $(this).val(state ? 'on' : 'off');
+        $(this).val(state ? '{$this->states['on']['value']}' : '{$this->states['off']['value']}');
 
         var pk = $(this).data('key');
         var value = $(this).val();


### PR DESCRIPTION
Issue: Switch now update resource's status to string 'on' or 'off'. It may cause bad request to server.

Fixed: update resource's status to switch's ```states' value```  instead of string 'on' & 'off'.