### PR TITLE
Fix bug when user can update any displayed field

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -193,7 +193,7 @@ class Form implements Renderable
      * @var array
      */
     protected $ignored = [];
-    
+
     /**
      * Ignored saving Display fields.
      *
@@ -561,7 +561,7 @@ class Form implements Renderable
     protected function removeIgnoredFields($input): array
     {
         Arr::forget($input, $this->ignored);
-        
+
         if ($this->ignoreDispayFields) {
             $this->builder->fields()->filter(function ($field) {
                 return is_a($field, self::$availableFields['display']);
@@ -1084,7 +1084,7 @@ class Form implements Renderable
 
         return $this;
     }
-    
+
     /**
      * Ignore Display fields to save.
      *

--- a/src/Form.php
+++ b/src/Form.php
@@ -193,6 +193,13 @@ class Form implements Renderable
      * @var array
      */
     protected $ignored = [];
+    
+    /**
+     * Ignored saving Display fields.
+     *
+     * @var bool
+     */
+    protected $ignoreDispayFields = false;
 
     /**
      * Collected field assets.
@@ -554,6 +561,14 @@ class Form implements Renderable
     protected function removeIgnoredFields($input): array
     {
         Arr::forget($input, $this->ignored);
+        
+        if ($this->ignoreDispayFields) {
+            foreach ($this->builder->fields() as $field) {
+                if (is_a($field, self::$availableFields['display']) && isset($input[$field->column()])) {
+                    Arr::forget($input, $field->column());
+                }
+            }
+        }
 
         return $input;
     }
@@ -1066,6 +1081,20 @@ class Form implements Renderable
     public function ignore($fields): self
     {
         $this->ignored = array_merge($this->ignored, (array) $fields);
+
+        return $this;
+    }
+    
+    /**
+     * Ignore Display fields to save.
+     *
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function ignoreDispayFields(bool $value = true): self
+    {
+        $this->ignoreDispayFields = $value;
 
         return $this;
     }

--- a/src/Form.php
+++ b/src/Form.php
@@ -563,11 +563,11 @@ class Form implements Renderable
         Arr::forget($input, $this->ignored);
         
         if ($this->ignoreDispayFields) {
-            foreach ($this->builder->fields() as $field) {
-                if (is_a($field, self::$availableFields['display']) && isset($input[$field->column()])) {
-                    Arr::forget($input, $field->column());
-                }
-            }
+            $this->builder->fields()->filter(function ($field) {
+                return is_a($field, self::$availableFields['display']);
+            })->each(function ($field) use (&$input) {
+                unset($input[$field->column()]);
+            });
         }
 
         return $input;


### PR DESCRIPTION
At this pull request I've added optional protection from updating displayed fields [which `$form->display()`] by optional ignoring that kind of fields. Now it's made with backwards compatibility.
But I think that better be safe, than sorry and make this behavior by default.

How to use:
`$form->ignoreDispayFields(bool);`

If security for you is in prior, than you can use it with `Form::init()` method @ `app/Admin/bootstrap.php` (https://laravel-admin.org/docs/#/en/model-form-init?id=form-initialization-settings): just add
`$form->ignoreDispayFields();` there.

I'm using `unset()` without `isset()` because of this https://stackoverflow.com/a/35822050/4941870 and that `It's easier to ask forgiveness than it is to get permission`.

P.S.: sure, you can just add all display fields to `ignore([])` but I found it very uncomfortable.