### PR TITLE
fix "/admin/auth/logs" page Authenticated Store XSS bug

### DIFF
--- a/src/Controllers/LogController.php
+++ b/src/Controllers/LogController.php
@@ -41,7 +41,7 @@ class LogController extends AdminController
                 return '<code>{}</code>';
             }
 
-            return '<pre>'.json_encode($input, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE).'</pre>';
+            return '<pre>'.json_encode($input, JSON_PRETTY_PRINT | JSON_HEX_TAG).'</pre>';
         });
 
         $grid->column('created_at', trans('admin.created_at'));


### PR DESCRIPTION
I finded xss from `src/Controllers/LogController.php` file. And fixed it.
Please validate it.

## Confirmation contents

- STEP 1.
Access to below url.
`http://127.0.0.1:8000/admin/auth/roles?_columns_=<img src=hoge onerror=alert(document.cookie)>`

- STEP 2.
Access to below url.
`http://127.0.0.1:8000/admin/auth/logs`

### Before

#### Screen
<img width="1112" alt="スクリーンショット 2020-01-31 11 38 59" src="https://user-images.githubusercontent.com/3177297/73508615-d9626280-441f-11ea-8274-c3ad1054519f.png">

#### View HTML source
<img width="479" alt="スクリーンショット 2020-01-31 11 35 53" src="https://user-images.githubusercontent.com/3177297/73508612-d8c9cc00-441f-11ea-9d67-37037d40658a.png">

### After
#### Screen
<img width="1382" alt="スクリーンショット 2020-01-31 11 36 32" src="https://user-images.githubusercontent.com/3177297/73508614-d9626280-441f-11ea-959c-7c623d76bfe2.png">

#### View HTML source
<img width="545" alt="スクリーンショット 2020-01-31 11 36 14" src="https://user-images.githubusercontent.com/3177297/73508613-d8c9cc00-441f-11ea-80c4-9e4d35a0c6d7.png">

