### PR TITLE
兼容 filter multipleSelect 参数值不为数组的情况，防止页面错乱

### DIFF
--- a/resources/views/filter/multipleselect.blade.php
+++ b/resources/views/filter/multipleselect.blade.php
@@ -1,6 +1,11 @@
 <select class="form-control {{ $class }}" name="{{$name}}[]" multiple style="width: 100%;">
     <option></option>
+    @php
+        $selected = request($name, []);
+        $selected = is_array($selected) ? $selected : [];
+    @endphp
+
     @foreach($options as $select => $option)
-        <option value="{{$select}}" {{ in_array((string)$select, request($name, []))  ?'selected':'' }}>{{$option}}</option>
+        <option value="{{$select}}" {{ in_array((string)$select, $selected) ? 'selected' : '' }}>{{$option}}</option>
     @endforeach
 </select>


### PR DESCRIPTION
字段过滤由 equal 修改为 in 时
before: $filter->equal('status', __('admin.status'));
after: $filter->in('status', __('admin.status'))->multipleSelect();

如果 url 上的参数还是 status=xxx 这种形式，页面会报错，并显示错乱