### PR TITLE
fix: qrcode popover not visible in div with overflow hidden

### DIFF
--- a/src/Grid/Displayers/QRCode.php
+++ b/src/Grid/Displayers/QRCode.php
@@ -14,6 +14,7 @@ class QRCode extends AbstractDisplayer
         $script = <<<'SCRIPT'
 $('.grid-column-qrcode').popover({
     html: true,
+    container: 'body',
     trigger: 'focus'
 });
 SCRIPT;

--- a/src/Grid/Displayers/QRCode.php
+++ b/src/Grid/Displayers/QRCode.php
@@ -34,7 +34,11 @@ SCRIPT;
 
         $img = sprintf(
             "<img src='https://api.qrserver.com/v1/create-qr-code/?size=%sx%s&data=%s' style='height:%spx;width:%spx;'/>",
-            $width, $height, $content, $height, $width
+            $width,
+            $height,
+            $content,
+            $height,
+            $width
         );
 
         return <<<HTML


### PR DESCRIPTION
修复了二维码在带有 `overflow-x:auto`  样式的 div 内被隐藏的问题，详情： #4450 