### PR TITLE
&nbsp; has been changed to space

### DIFF
--- a/src/Grid/Displayers/Label.php
+++ b/src/Grid/Displayers/Label.php
@@ -23,6 +23,6 @@ class Label extends AbstractDisplayer
             }
 
             return "<span class='label label-{$style}'>$item</span>";
-        })->implode('&nbsp;');
+        })->implode(' ');
     }
 }


### PR DESCRIPTION
`&nbsp;` is a nowrap character that could break your page because of long items per row