### PR TITLE
让删除操作保证事务一致性

### DIFF
--- a/src/Grid/Actions/Delete.php
+++ b/src/Grid/Actions/Delete.php
@@ -29,7 +29,9 @@ class Delete extends RowAction
         ];
 
         try {
-            $model->delete();
+            DB::transaction(function () use ($model) {
+                $model->delete();
+            });
         } catch (\Exception $exception) {
             return $this->response()->error("{$trans['failed']} : {$exception->getMessage()}");
         }


### PR DESCRIPTION
在使用了Observer时，让删除操作保证事务一致性