### PR TITLE
$querybuilder reassign

### DIFF
--- a/src/Grid/Exporters/AbstractExporter.php
+++ b/src/Grid/Exporters/AbstractExporter.php
@@ -101,8 +101,8 @@ abstract class AbstractExporter implements ExporterInterface
                 ->select([$keyName])
                 ->setEagerLoads([])
                 ->forPage($this->page, $perPage)->get();
-
-            $queryBuilder->whereIn($keyName, $scope->pluck($keyName));
+			// If $querybuilder is a Model, it must be reassigned, unless it is a eloquent/query builder.
+            $queryBuilder = $queryBuilder->whereIn($keyName, $scope->pluck($keyName));
         }
 
         return $queryBuilder;


### PR DESCRIPTION
\Encore\Admin\Grid\Exporters\AbstractExporter::getQuery() #line107
必须重新赋值：$queryBuilder = $queryBuilder->whereIn($keyName, $scope->pluck($keyName));
Because sometime $queryBuilder is a Model.