### PR TITLE
fix: router name error.

### DIFF
--- a/src/Console/stubs/routes.stub
+++ b/src/Console/stubs/routes.stub
@@ -11,6 +11,6 @@ Route::group([
     'as'            => config('admin.route.prefix') . '.',
 ], function (Router $router) {
 
-    $router->get('/', 'HomeController@index')->name('admin.home');
+    $router->get('/', 'HomeController@index')->name('home');
 
 });


### PR DESCRIPTION
bug: 加了 as 参数后，默认的 home 路由name 会变成  admin.admin.home