### PR TITLE
修正新增form表单时无法添加非自增主键的问题

### DIFF
--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -566,10 +566,13 @@ SCRIPT;
         }
 
         $reservedColumns = [
-            $this->form->model()->getKeyName(),
             $this->form->model()->getCreatedAtColumn(),
             $this->form->model()->getUpdatedAtColumn(),
         ];
+
+        if ($this->form->model()->incrementing) {
+            $reservedColumns[] = $this->form->model()->getKeyName();
+        }
 
         $this->form->getLayout()->removeReservedFields($reservedColumns);
 


### PR DESCRIPTION
判断模型`incrememting`为`true`(自增主键)时,才加入保留字段,稍后清除(removeReservedFields)