### PR TITLE
修复JS隐藏语法问题

### DIFF
--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -635,7 +635,7 @@ SCRIPT;
     protected function addCascadeScript()
     {
         $script = <<<SCRIPT
-(function () {
+;(function () {
     $('form.{$this->formClass}').submit(function (e) {
         e.preventDefault();
         $(this).find('div.cascade-group.hide :input').attr('disabled', true);


### PR DESCRIPTION
这段js的开头即为小括号，倘若在这段之前的js是大括号结尾的，则这里会被解析成上个大括号结尾方法的入参，从而引发语法错误。前面添加分号可以确保与上一段代码分离。