### PR TITLE
Set value for select in editing mode

### DIFF
--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -143,7 +143,11 @@ $(document).on('change', "{$this->getElementClassSelector()}", function () {
                 d.text = d.$textField;
                 return d;
             })
-        }).trigger('change');
+        });
+        if (target.data('value')) {
+            $(target).val(target.data('value'));
+        }
+        $(target).trigger('change');
     });
 });
 EOT;


### PR DESCRIPTION
I'm using this template. But in editing mode, city field not selected by the "selected" value. Only selects first value.
```
$form->select('province')->options(...)->load('city', '/api/city');

$form->select('city');
```
Example usage
```
if ($form->isCreating()) {
    $form->select('city');
} else {
    $form->select('city')->default($form->model()->city);
}

```
Now, looking for value from data-value attribute. If exists, set the value than trigger change.