### PR TITLE
修复权限http方法和http路径不填写时会导致普通用户角色可以访问所有路径的bug

### DIFF
--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -63,10 +63,6 @@ class Permission extends Model
      */
     public function shouldPassThrough(Request $request): bool
     {
-        if (empty($this->http_method) && empty($this->http_path)) {
-            return true;
-        }
-
         $method = $this->http_method;
 
         $matches = array_map(function ($path) use ($method) {


### PR DESCRIPTION
权限资源也应该像菜单一样有层级关系，父级菜单对应父级权限时，该权限http方法和http路径应该可以为空，但是在Permission Model 里判断权限时，遇到为空的直接算匹配成功了，这样就导致了没有权限用户可以访问所有的路由（虽然只能看到权限内的菜单)