### PR TITLE
(re)enable relation-sort

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -532,7 +532,9 @@ class Model
 
         $columnNameContainsDots = Str::contains($columnName, '.');
         $isRelation = $this->queries->contains(function ($query) use ($columnName) {
-            return $query['method'] === 'with' && in_array($columnName, $query['arguments'], true);
+            $relationName = explode('.', $columnName)[0];
+
+            return $query['method'] === 'with' && in_array($relationName, $query['arguments'], true);
         });
         if ($columnNameContainsDots === true && $isRelation) {
             $this->setRelationSort($columnName);
@@ -636,7 +638,7 @@ class Model
 
             return [
                 $relatedTable,
-                $relation->{$foreignKeyMethod}(),
+                $relation->getParent()->getTable().'.'.$relation->{$foreignKeyMethod}(),
                 '=',
                 $relatedTable.'.'.$relation->getRelated()->getKeyName(),
             ];


### PR DESCRIPTION
Fixes two issues:

1. cannot sort by a related attribute. Because `setSort` doesn't compare `relation-name`s  but `relation-name` and `relation-name.attribute`.
2. cannot count rows when sorted by a related attribute.  
This causes when *foreign key* and *related primary key* are named identically.  
(e.g. `foo.foo_code` and `bar.foo_code`; I don't think this is good naming though)