### PR TITLE
数据导出添加 export->title 方法，允许定制修改 CSV 表头

### DIFF
--- a/src/Grid/Exporters/CsvExporter.php
+++ b/src/Grid/Exporters/CsvExporter.php
@@ -198,7 +198,7 @@ class CsvExporter extends AbstractExporter
             ->mapWithKeys(function (Column $column) {
                 $columnName = $column->getName();
                 $columnTitle = $column->getLabel();
-                if(isset($this->titleCallbacks[$columnName])) {
+                if (isset($this->titleCallbacks[$columnName])) {
                     $columnTitle = $this->titleCallbacks[$columnName]($columnTitle);
                 }
 

--- a/src/Grid/Exporters/CsvExporter.php
+++ b/src/Grid/Exporters/CsvExporter.php
@@ -32,6 +32,11 @@ class CsvExporter extends AbstractExporter
     protected $columnCallbacks;
 
     /**
+     * @var []\Closure
+     */
+    protected $titleCallbacks;
+
+    /**
      * @var array
      */
     protected $visibleColumns;
@@ -113,6 +118,19 @@ class CsvExporter extends AbstractExporter
     }
 
     /**
+     * @param string   $name
+     * @param \Closure $callback
+     *
+     * @return $this
+     */
+    public function title(string $name, \Closure $callback): self
+    {
+        $this->titleCallbacks[$name] = $callback;
+
+        return $this;
+    }
+
+    /**
      * Get download response headers.
      *
      * @return array
@@ -178,7 +196,13 @@ class CsvExporter extends AbstractExporter
     {
         $titles = $this->grid->visibleColumns()
             ->mapWithKeys(function (Column $column) {
-                return [$column->getName() => $column->getLabel()];
+                $columnName = $column->getName();
+                $columnTitle = $column->getLabel();
+                if(isset($this->titleCallbacks[$columnName])) {
+                    $columnTitle = $this->titleCallbacks[$columnName]($columnTitle);
+                }
+
+                return [$columnName => $columnTitle];
             });
 
         if ($this->onlyColumns) {


### PR DESCRIPTION
refer issues #4733 
搭配 export->column，用户现在有足够工具自行转码了。