### PR TITLE
Fix progress bar width in grid & Group support for checkbox field options

### DIFF
--- a/resources/views/form/checkbox.blade.php
+++ b/resources/views/form/checkbox.blade.php
@@ -15,6 +15,28 @@
 
         @include('admin::form.error')
 
+        @if($groups)
+
+        @foreach($groups as $group => $options)
+
+            <p style="{{ $canCheckAll ? 'margin: 15px 0 0 0;' : 'margin: 7px 0 0 0;' }}padding-bottom: 5px;border-bottom: 1px solid #eee;display: inline-block;">{{ $group }}</p>
+
+            @foreach($options as $option => $label)
+
+            <div class="checkbox icheck">
+
+                <label>
+                    <input type="checkbox" name="{{$name}}[]" value="{{$option}}" class="{{$class}}" {{ false !== array_search($option, array_filter(old($column, $value ?? []))) || ($value === null && in_array($option, $checked)) ?'checked':'' }} {!! $attributes !!} />&nbsp;{{$label}}&nbsp;&nbsp;
+                </label>
+
+            </div>
+
+            @endforeach
+
+        @endforeach
+
+        @else
+
         @foreach($options as $option => $label)
 
             {!! $inline ? '<span class="icheck">' : '<div class="checkbox icheck">' !!}
@@ -26,6 +48,8 @@
             {!! $inline ? '</span>' :  '</div>' !!}
 
         @endforeach
+
+        @endif
 
         <input type="hidden" name="{{$name}}[]">
 

--- a/src/Grid/Displayers/ProgressBar.php
+++ b/src/Grid/Displayers/ProgressBar.php
@@ -15,7 +15,7 @@ class ProgressBar extends AbstractDisplayer
         return <<<EOT
 <div class="row" style="min-width: 100px;">
     <span class="col-sm-3" style="color:#777;">{$this->value}%</span>
-    <div class="progress progress-$size col-sm-9" style="padding-left: 0;width: 100px;"> 
+    <div class="progress progress-$size col-sm-9" style="padding-left: 0;padding-right: 0;width: 100px;"> 
         <div class="progress-bar $style" role="progressbar" aria-valuenow="{$this->value}" aria-valuemin="0" aria-valuemax="$max" style="width: {$this->value}%">
         </div>
     </div>


### PR DESCRIPTION
Fixes full width for 100% progress error.

![2020-06-27_21-43-03](https://user-images.githubusercontent.com/8195419/85929732-e5175f80-b8bf-11ea-9e81-a52df23a6db0.png)

-----

Group support for checkbox field options

Example:
```
$form->checkbox('group1', __('Groupped Checkbox 1'))
    ->groups(
        [
            'Group 1' => [
                'key1' => 'Value 1',
                'key2' => 'Value 2',
            ],
            'Group 2' => [
                'key3' => 'Value 3',
                'key4' => 'Value 4',
                'key5' => 'Value 5',
            ],
        ]
    );

$form->checkbox('group2', __('Groupped Checkbox 2'))
    ->groups(
        [
            'Group 1' => [
                'key1' => 'Value 1',
                'key2' => 'Value 2',
            ],
            'Group 2' => [
                'key3' => 'Value 3',
                'key4' => 'Value 4',
                'key5' => 'Value 5',
            ],
        ]
    )
    ->canCheckAll();
```
![2020-06-27_23-54-04](https://user-images.githubusercontent.com/8195419/85932153-29abf680-b8d2-11ea-8be1-a5fb20c9fde3.png)

