### PR TITLE
Optimization: when the model primary key of form is not self increasing, the primary key column can be edited

### DIFF
--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -565,13 +565,15 @@ SCRIPT;
             return;
         }
 
+        $model = $this->form->model();
+
         $reservedColumns = [
-            $this->form->model()->getCreatedAtColumn(),
-            $this->form->model()->getUpdatedAtColumn(),
+            $model->getCreatedAtColumn(),
+            $model->getUpdatedAtColumn(),
         ];
 
-        if ($this->form->model()->incrementing) {
-            $reservedColumns[] = $this->form->model()->getKeyName();
+        if ($model->getIncrementing()) {
+            $reservedColumns[] = $model->getKeyName();
         }
 
         $this->form->getLayout()->removeReservedFields($reservedColumns);

--- a/src/Grid/Concerns/HasHotKeys.php
+++ b/src/Grid/Concerns/HasHotKeys.php
@@ -17,7 +17,7 @@ trait HasHotKeys
 $(document).off('keydown').keydown(function(e) {
     var tag = e.target.tagName.toLowerCase();
     
-    if (tag == 'input' || tag == 'textarea') {
+    if (tag == 'input' || tag == 'textarea' || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
         return;
     }
 
@@ -36,9 +36,7 @@ $(document).off('keydown').keydown(function(e) {
             \$box.find('#{$filterID}').toggleClass('hide');
             break;
         case 67: // `c` go to create page 
-            if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
-                \$box.find('.grid-create-btn>a').trigger('click');
-            }
+            \$box.find('.grid-create-btn>a').trigger('click');
             break; 
         case 37: // `left` for go to prev page
             \$current_page.prev().find('a').trigger('click');


### PR DESCRIPTION
It's not appropriate to delete the "primary key column" directly in grid form, without considering that the primary key is not self increasing.