### PR TITLE
多图上传使用排序功能时会导致获取不到图片验证规则

### DIFF
--- a/src/Form/Field/MultipleFile.php
+++ b/src/Form/Field/MultipleFile.php
@@ -63,10 +63,6 @@ class MultipleFile extends Field
             return false;
         }
 
-        if (request()->has(static::FILE_SORT_FLAG)) {
-            return false;
-        }
-
         if ($this->validator) {
             return $this->validator->call($this, $input);
         }


### PR DESCRIPTION
多图上传如果加上sortable() 时就会在页面增加 _file_sort_字段，此处的判断正好阻止了获取图片的验证规则，导致多图上传时验证规则失效，直接删除该代码即可，我看到之前有人已经提了这个问题的PR ，但是修改方法不是太好，该判断没有任何意义，因为这里不像删除图片是异步。排序是和修改一块提交的，所以删除代码即可