### PR TITLE
解决使用了 display 匿名函数时，别的匿名函数获取不到 value 的问题。

### DIFF
--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -517,7 +517,8 @@ class Column
 
             $callback = $this->bindOriginalRowModel($callback, $key);
             $value = call_user_func_array($callback, [$value, $this]);
-
+            $this->original = $value;
+            
             if (($value instanceof static) &&
                 ($last = array_pop($this->displayCallbacks))
             ) {


### PR DESCRIPTION
解决多个回调方法，后面的回调方法无法获取当前列 value 的问题，比如 copyable 在使用了 display 回调函数时会无效。