### PR TITLE
修复标签样式类被覆盖问题

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -1361,12 +1361,13 @@ class Field implements Renderable
 
     /**
      * @param array $labelClass
+     * @param boolean $replace
      *
      * @return self
      */
-    public function setLabelClass(array $labelClass): self
+    public function setLabelClass(array $labelClass, $replace = false): self
     {
-        $this->labelClass = $labelClass;
+        $this->labelClass = $replace ? $labelClass : array_merge($this->labelClass, $labelClass);
 
         return $this;
     }

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -1361,7 +1361,7 @@ class Field implements Renderable
 
     /**
      * @param array $labelClass
-     * @param boolean $replace
+     * @param bool $replace
      *
      * @return self
      */


### PR DESCRIPTION
当 hasMany使用 table 时，表格内的 label 被添加了hidden类以隐藏，但如果此时设置了required属性，则会添加了asterisk类覆盖掉了hidden类，以致显示错误。
本来计划改为 array_merge的，但又考虑到有需要覆盖的可能，故加了一个参数以确定是覆盖还是合并