### PR TITLE
Action内的select联动不生效Bug Fix

### DIFF
--- a/resources/views/actions/form/modal.blade.php
+++ b/resources/views/actions/form/modal.blade.php
@@ -5,7 +5,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                 <h4 class="modal-title">{{ $title }}</h4>
             </div>
-            <form>
+            <form class="fields-group">
             <div class="modal-body">
                 @foreach($fields as $field)
                     {!! $field->render() !!}


### PR DESCRIPTION
由于Action内的select联动需要寻找最新的fields-group节点，但是action内的form没有此节点，导致select联动不生效。