### PR TITLE
fix: Added ability to translate the breadcrumbs

### DIFF
--- a/resources/views/content.blade.php
+++ b/resources/views/content.blade.php
@@ -43,7 +43,7 @@
             <li><a href="{{ admin_url('/') }}"><i class="fa fa-dashboard"></i> {{__('Home')}}</a></li>
             @for($i = 2; $i <= count(Request::segments()); $i++)
                 <li>
-                {{ucfirst(Request::segment($i))}}
+                {{__(ucfirst(Request::segment($i)))}}
                 </li>
             @endfor
         </ol>


### PR DESCRIPTION
I added ability to translate without extending the index(), edit() and create() methods. IMHO, extending a index(), edit() and create() methods is irrational for translation of the breadcrumb\'s text.
This commit can help us avoid duplicating the code in controllers :)
The translation will work even on the create and edit pages, not like now :)
The small commit, but the very good changes :)

Translation before changes:

```php
public function index(Content $content): Content
{
    $content = parent::index($content);

    return $content
        ->breadcrumb([
            'text' => trans('breadcrumbs.sliders'),
        ]);
}

public function edit($id, Content $content): Content
{
    $content = parent::edit($id, $content);

    return $content
        ->breadcrumb(
            ['text' => trans('breadcrumbs.sliders'), 'url' => route('admin.sliders.index')],
            ['text' => $id],
            ['text' => trans('breadcrumbs.edit')]
        );
}

public function create(Content $content)
{
    $content = parent::create($content);

    return $content
        ->breadcrumb(
                [ 'text' => trans('breadcrumbs.sliders'), 'url' => route('admin.sliders.index')],
                [ 'text' => trans('breadcrumbs.create') ]
        );
}
```

Translation after changes(create a file /resources/langs/ru)
```json
{
    "Home": "Главная",
    "Sliders": "Слайдеры",
    "Create": "Создание",
    "Edit": "Редактирование"
}
```

Best Regards, sd-evo
Thanks :)