### PR TITLE
fixes issue 4802: bug in form linkage on 

### DIFF
--- a/src/Form/Field/CanCascadeFields.php
+++ b/src/Form/Field/CanCascadeFields.php
@@ -83,7 +83,7 @@ trait CanCascadeFields
 
     /**
      * @param string $operator
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return string
      */
@@ -92,9 +92,9 @@ trait CanCascadeFields
         // took from addCascadeScript()
         $must_escape = ['=', '>', '<', '>=', '<=', '!='];
         if (($index = array_search($operator, $must_escape)) !== false) {
-          $operator_escaped = "op$index";
+            $operator_escaped = "op$index";
         } else {
-          $operator_escaped = $operator;
+            $operator_escaped = $operator;
         }
 
         if (is_array($value)) {
@@ -111,7 +111,7 @@ trait CanCascadeFields
      */
     protected function applyCascadeConditions()
     {
-        if( $this->form ) {
+        if ($this->form) {
             $this->form->fields()
                 ->filter(function (Form\Field $field) {
                     return $field instanceof CascadeGroup

--- a/src/Form/Field/CanCascadeFields.php
+++ b/src/Form/Field/CanCascadeFields.php
@@ -223,7 +223,7 @@ trait CanCascadeFields
                 group.addClass('hide');
             }
         });
-    })
+    }).trigger('{$this->cascadeEvent}')
 })();
 SCRIPT;
 

--- a/src/Form/Field/CanCascadeFields.php
+++ b/src/Form/Field/CanCascadeFields.php
@@ -256,4 +256,11 @@ SCRIPT;
                 throw new \InvalidArgumentException('Invalid form field type');
         }
     }
+
+    /**
+     * Get element class string.
+     *
+     * @return mixed
+     */
+    abstract public function getElementClassString();
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -109,5 +109,4 @@ class TestCase extends BaseTestCase
             parent::assertFileNotExists($filename, $message);
         }
     }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -95,4 +95,19 @@ class TestCase extends BaseTestCase
 
         (new CreateTestTables())->up();
     }
+
+    /**
+     * Asserts that a file does not exist.
+     */
+    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+    {
+        if (method_exists(parent::class, 'assertFileDoesNotExist')) {
+            // PHPUnit 9
+            parent::assertFileDoesNotExist($filename, $message);
+        } else {
+            // PHPUnit 8
+            parent::assertFileNotExists($filename, $message);
+        }
+    }
+
 }

--- a/tests/UserGridTest.php
+++ b/tests/UserGridTest.php
@@ -139,7 +139,10 @@ class UserGridTest extends TestCase
 
     public function testLikeFilter()
     {
-        $this->seedsTable(50);
+        $this->seedsTable(49);
+
+        $u = factory(\Tests\Models\User::class)->create(['username' => 'mi']);
+        $u->profile()->save(factory(\Tests\Models\Profile::class)->make());
 
         $this->visit('admin/users')
             ->see('Users');


### PR DESCRIPTION
1- As shown on issue 4802 (I had to use Google Translator, sorry), the class used to toggle elements depends only on values. This PR includes the operator on that class.

Some operators (=, != etc) could cause problems on classname, so I replaced them with op0, op1 etc.

2- While testing this behavior, I noticed that on page load, if the radio was previously checked, the dependet element doesn't show. So I put a trigger() to run the callback.