### PR TITLE
feature #4794: you can publish laravel-admin's views now

### DIFF
--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -71,7 +71,10 @@ class AdminServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'admin');
+        $this->loadViewsFrom([
+            resource_path('/views/vendor/laravel-admin'),
+            __DIR__.'/../resources/views'
+        ], 'admin');
 
         $this->ensureHttps();
 
@@ -117,6 +120,7 @@ class AdminServiceProvider extends ServiceProvider
             $this->publishes([__DIR__.'/../resources/lang' => resource_path('lang')], 'laravel-admin-lang');
             $this->publishes([__DIR__.'/../database/migrations' => database_path('migrations')], 'laravel-admin-migrations');
             $this->publishes([__DIR__.'/../resources/assets' => public_path('vendor/laravel-admin')], 'laravel-admin-assets');
+            $this->publishes([__DIR__.'/../resources/views' => resource_path('/views/vendor/laravel-admin')], 'laravel-admin-views');
         }
     }
 

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -18,7 +18,7 @@ class PublishCommand extends Command
      *
      * @var string
      */
-    protected $description = "re-publish laravel-admin's assets, configuration, language and migration files. If you want overwrite the existing files, you can add the `--force` option";
+    protected $description = "re-publish laravel-admin's assets, configuration, language, migration files and views. If you want overwrite the existing files, you can add the `--force` option";
 
     /**
      * Execute the console command.


### PR DESCRIPTION
The following commands are available:

1) publish all
```php artisan vendor:publish --provider="Encore\Admin\AdminServiceProvider"```

2) publish config only
```php artisan vendor:publish --provider="Encore\Admin\AdminServiceProvider" --tag=laravel-admin-config```

3) publish lang only
```php artisan vendor:publish --provider="Encore\Admin\AdminServiceProvider" --tag=laravel-admin-lang```

4) publish migrations only
```php artisan vendor:publish --provider="Encore\Admin\AdminServiceProvider" --tag=laravel-admin-migrations```

5) publish assets only
```php artisan vendor:publish --provider="Encore\Admin\AdminServiceProvider" --tag=laravel-admin-assets```

6) publish views only(new)
```php artisan vendor:publish --provider="Encore\Admin\AdminServiceProvider" --tag=laravel-admin-views```