### PR TITLE
v1.8.2JS问题修复

### DIFF
--- a/src/Form/Field/Slider.php
+++ b/src/Form/Field/Slider.php
@@ -25,7 +25,7 @@ class Slider extends Field
     {
         $option = json_encode($this->options);
 
-        $this->script = "$('{$this->getElementClassSelector()}').ionRangeSlider($option)";
+        $this->script = "$('{$this->getElementClassSelector()}').ionRangeSlider($option);";
 
         return parent::render();
     }


### PR DESCRIPTION
在最新的v1.8.2中，不同的JS代码合并到一行，导致没有加“ ;  ”的JS语句出错