### PR TITLE
v1.8.2JS问题修复

### DIFF
--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -122,7 +122,7 @@ $('.{$checkAllClass}').iCheck({checkboxClass:'icheckbox_minimal-blue'}).on('ifCh
     } else {
         $('{$this->getElementClassSelector()}').iCheck('uncheck');
     }
-})
+});
 SCRIPT;
             $this->addVariables(['checkAllClass' => $checkAllClass]);
         }


### PR DESCRIPTION
在最新的v1.8.2中，不同的JS代码合并到一行，导致没有加“ ; ”的JS语句出错