### PR TITLE
Make formatLabel methods be similar in Grid/Form/Show and fix bug

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -316,11 +316,14 @@ class Field implements Renderable
      */
     protected function formatLabel($arguments = []): string
     {
+        if ($label) {
+            return $label;
+        }
+
         $column = is_array($this->column) ? current($this->column) : $this->column;
+        $label = ucfirst($column);
 
-        $label = $arguments[0] ?? ucfirst($column);
-
-        return str_replace(['.', '_', '->'], ' ', $label);
+        return __(str_replace(['.', '_', '->'], ' ', $label));
     }
 
     /**

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -428,10 +428,7 @@ class HasMany extends Field
 
                 $model = $relation->getRelated()->replicate()->forceFill($data);
 
-                $forms[$key] = $this->buildNestedForm($this->column, function ($form) use ($key) {
-                    $form->setKey($key);
-                    call_user_func($this->builder, $form);
-                }, $model)
+                $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $model)
                     ->fill($data);
             }
         } else {

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -428,7 +428,10 @@ class HasMany extends Field
 
                 $model = $relation->getRelated()->replicate()->forceFill($data);
 
-                $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $model)
+                $forms[$key] = $this->buildNestedForm($this->column, function ($form) use ($key) {
+                    $form->setKey($key);
+                    call_user_func($this->builder, $form);
+                }, $model)
                     ->fill($data);
             }
         } else {

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -127,9 +127,13 @@ abstract class AbstractFilter
      */
     protected function formatLabel($label)
     {
-        $label = $label ?: ucfirst($this->column);
+        if ($label) {
+            return $label;
+        }
 
-        return str_replace(['.', '_'], ' ', $label);
+        $label = ucfirst($this->column);
+
+        return __(str_replace(['.', '_'], ' ', $label));
     }
 
     /**

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -153,9 +153,13 @@ class Field implements Renderable
      */
     protected function formatLabel($label)
     {
-        $label = $label ?: ucfirst($this->name);
+        if ($label) {
+            return $label;
+        }
 
-        return str_replace(['.', '_'], ' ', $label);
+        $label = ucfirst($this->name);
+
+        return __(str_replace(['.', '_'], ' ', $label));
     }
 
     /**


### PR DESCRIPTION
We had an issue - if we had a dot in a label it was removed from Show and Form, but it was displayed in Grid column name.
After code review - Grid have formatLabel method different (better) than Form and Show - it just passes custom labels and only for 
"no label" it gets column name and removes dots etc.
Moreover, Grid tries to translate label from column name - I think it could be a good idea so I made it too in Show/Form.