### PR TITLE
Add Regex to match the permission by the request fullURL

### DIFF
--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -111,13 +111,16 @@ class Permission extends Model
      */
     protected function matchRequest(array $match, Request $request): bool
     {
+        $match_pattern = NULL;
         if ($match['path'] == '/') {
             $path = '/';
         } else {
+            $match_pattern = preg_replace('/(?<!\\\\)\//i','\/', $match['path']);
             $path = trim($match['path'], '/');
         }
 
-        if (!$request->is($path)) {
+
+        if (!$request->is($path) && (!is_null($match_pattern) && !preg_match("/".$match_pattern."/", $request->fullUrl())) ) {
             return false;
         }
 


### PR DESCRIPTION
Add Regex to match the permission by the request full URL.

Currently, the `matchRequest` method is fixed by `Laravel Request->is` method which does not allow to use RegEx to match the URL path.
In some cases, admins will need to provide permission matched by RegEx. 
Example:
The permission that only allows the manager to filter by name (but not show all the user list.)
Admin could use some RegEx like that `/admin/users\?.*&?name=([a-zA-Z]+).*`
That will not allow accessing path `/admin/users`
