### PR TITLE
force file type to image with Image field

### DIFF
--- a/src/Form/Field/Image.php
+++ b/src/Form/Field/Image.php
@@ -45,4 +45,17 @@ class Image extends File
 
         return $path;
     }
+
+    /**
+     * force file type to image
+     * @param $file
+     * @return array|bool|int[]|string[]
+     */
+    public function guessPreviewType($file)
+    {
+        $extra = parent::guessPreviewType($file);
+        $extra['type'] = 'image';
+
+        return $extra;
+    }
 }


### PR DESCRIPTION
修复无后缀网络图片无法正常显示问题 例如微信头像: https://thirdwx.qlogo.cn/mmopen/vi_32/xxxx/132