### PR TITLE
Make formatLabel functions be similar in Grid/Form/Show and fix bug - do not remove dot from custom labels.

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -323,7 +323,7 @@ class Field implements Renderable
         $column = is_array($this->column) ? current($this->column) : $this->column;
         $label = ucfirst($column);
 
-        return __(str_replace(['.', '_', '->'], ' ', $label));
+        return str_replace(['.', '_', '->'], ' ', $label);
     }
 
     /**

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -316,11 +316,14 @@ class Field implements Renderable
      */
     protected function formatLabel($arguments = []): string
     {
+        if ($label) {
+            return $label;
+        }
+
         $column = is_array($this->column) ? current($this->column) : $this->column;
+        $label = ucfirst($column);
 
-        $label = $arguments[0] ?? ucfirst($column);
-
-        return str_replace(['.', '_', '->'], ' ', $label);
+        return __(str_replace(['.', '_', '->'], ' ', $label));
     }
 
     /**

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -316,8 +316,8 @@ class Field implements Renderable
      */
     protected function formatLabel($arguments = []): string
     {
-        if ($label) {
-            return $label;
+        if (isset($arguments[0])) {
+            return $arguments[0];
         }
 
         $column = is_array($this->column) ? current($this->column) : $this->column;

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -313,7 +313,7 @@ class Column
 
         $label = ucfirst($this->name);
 
-        return __(str_replace(['.', '_'], ' ', $label));
+        return str_replace(['.', '_'], ' ', $label);
     }
 
     /**

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -127,9 +127,13 @@ abstract class AbstractFilter
      */
     protected function formatLabel($label)
     {
-        $label = $label ?: ucfirst($this->column);
+        if ($label) {
+            return $label;
+        }
 
-        return str_replace(['.', '_'], ' ', $label);
+        $label = ucfirst($this->column);
+
+        return __(str_replace(['.', '_'], ' ', $label));
     }
 
     /**

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -133,7 +133,7 @@ abstract class AbstractFilter
 
         $label = ucfirst($this->column);
 
-        return __(str_replace(['.', '_'], ' ', $label));
+        return str_replace(['.', '_'], ' ', $label);
     }
 
     /**

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -153,9 +153,13 @@ class Field implements Renderable
      */
     protected function formatLabel($label)
     {
-        $label = $label ?: ucfirst($this->name);
+        if ($label) {
+            return $label;
+        }
 
-        return str_replace(['.', '_'], ' ', $label);
+        $label = ucfirst($this->name);
+
+        return __(str_replace(['.', '_'], ' ', $label));
     }
 
     /**

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -159,7 +159,7 @@ class Field implements Renderable
 
         $label = ucfirst($this->name);
 
-        return __(str_replace(['.', '_'], ' ', $label));
+        return str_replace(['.', '_'], ' ', $label);
     }
 
     /**


### PR DESCRIPTION
We had an issue - if we had a dot in a label it was removed from Show and Form, but it was displayed in Grid column name.
After code review - Grid have formatLabel method different (better) than Form and Show - it just passes custom labels and only for
"no label" it gets column name and removes dots etc.
Moreover, Grid tries to translate label from column name - I think it could be a good idea so I made it too in Show/Form.