### PR TITLE
修改模型relation的get方法

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -372,7 +372,7 @@ class Model
         }
 
         if ($this->relation) {
-            $this->model = $this->relation->getQuery();
+            $this->model = $this->relation;
         }
 
         $this->setSort();


### PR DESCRIPTION
$this->relation 本身已经有__call方法直接调用query的方法了，不必再getQuery()，而且使用了getQuery()得到的builder，不会去获取pivot关系表内容，需要relation模型才可获取