### PR TITLE
Fix multiple select filter

### DIFF
--- a/resources/views/filter/multipleselect.blade.php
+++ b/resources/views/filter/multipleselect.blade.php
@@ -1,6 +1,6 @@
 <select class="form-control {{ $class }}" name="{{$name}}[]" multiple style="width: 100%;">
     <option></option>
     @foreach($options as $select => $option)
-        <option value="{{$select}}" {{ in_array((string)$select, request($name, []))  ?'selected':'' }}>{{$option}}</option>
+        <option value="{{$select}}" {{ in_array((string)$select, (array)$value) ?'selected':'' }}>{{$option}}</option>
     @endforeach
 </select>


### PR DESCRIPTION
After using `multipleSelect` filter with dot-notation (e.g. `categories.id`), `option` elements don't have `selected` prop.

![demo](https://user-images.githubusercontent.com/15811084/93880761-f0d8bd80-fd18-11ea-92c6-656546c995e5.gif)

In the template `views/filter/multipleselect.blade.php`, `request($name, [])` is used to get current value, but it will always be `[]` when dot-notation is used. I fixed that with the use of `$value` passed from controller instead of `request($name)`. I would appreciate it if you could confirm this.