### PR TITLE
Multiple Image Upload thumbnail creation and deletion fix.

### DIFF
--- a/src/Form/Field/ImageField.php
+++ b/src/Form/Field/ImageField.php
@@ -131,18 +131,42 @@ trait ImageField
         }
 
         foreach ($this->thumbnails as $name => $_) {
-            // We need to get extension type ( .jpeg , .png ...)
-            $ext = pathinfo($this->original, PATHINFO_EXTENSION);
+            /*  Refactoring actual remove lofic to another method destroyThumbnailFile()
+            to make deleting thumbnails work with multiple as well as 
+            single image upload. */
 
-            // We remove extension from file name so we can append thumbnail type
-            $path = Str::replaceLast('.'.$ext, '', $this->original);
+            if (is_array($this->original)) {
+                if (empty($this->original)) {
+                    continue;
+                }
 
-            // We merge original name + thumbnail name + extension
-            $path = $path.'-'.$name.'.'.$ext;
-
-            if ($this->storage->exists($path)) {
-                $this->storage->delete($path);
+                foreach ($this->original as $original) {
+                    $this->destroyThumbnailFile($original, $name);
+                }
+            } else {
+                $this->destroyThumbnailFile($this->original, $name);
             }
+        }
+    }
+
+    /**
+     * Remove thumbnail file from disk.
+     *
+     * @return void.
+     */
+    public function destroyThumbnailFile($original, $name)
+    {
+
+        $ext = @pathinfo($original, PATHINFO_EXTENSION);
+
+        // We remove extension from file name so we can append thumbnail type
+        $path = @Str::replaceLast('.' . $ext, '', $original);
+
+        // We merge original name + thumbnail name + extension
+        $path = $path . '-' . $name . '.' . $ext;
+
+        if ($this->storage->exists($path)) {
+            $this->storage->delete($path);
         }
     }
 
@@ -160,10 +184,10 @@ trait ImageField
             $ext = pathinfo($this->name, PATHINFO_EXTENSION);
 
             // We remove extension from file name so we can append thumbnail type
-            $path = Str::replaceLast('.'.$ext, '', $this->name);
+            $path = Str::replaceLast('.' . $ext, '', $this->name);
 
             // We merge original name + thumbnail name + extension
-            $path = $path.'-'.$name.'.'.$ext;
+            $path = $path . '-' . $name . '.' . $ext;
 
             /** @var \Intervention\Image\Image $image */
             $image = InterventionImage::make($file);

--- a/src/Form/Field/MultipleFile.php
+++ b/src/Form/Field/MultipleFile.php
@@ -96,8 +96,8 @@ class MultipleFile extends Field
         $rules = $input = [];
 
         foreach ($value as $key => $file) {
-            $rules[$this->column.$key] = $this->getRules();
-            $input[$this->column.$key] = $file;
+            $rules[$this->column . $key] = $this->getRules();
+            $input[$this->column . $key] = $file;
         }
 
         return [$rules, $input];
@@ -367,6 +367,14 @@ EOT;
         $path = Arr::get($files, $key);
 
         if (!$this->retainable && $this->storage->exists($path)) {
+            /* If this field class is using ImageField trait i.e MultipleImage field, 
+            we loop through the thumbnails to delete them as well. */
+
+            if (isset($this->thumbnails) && method_exists($this, 'destroyThumbnailFile')) {
+                foreach ($this->thumbnails as $name => $_) {
+                    $this->destroyThumbnailFile($path, $name);
+                }
+            }
             $this->storage->delete($path);
         }
 

--- a/src/Form/Field/MultipleImage.php
+++ b/src/Form/Field/MultipleImage.php
@@ -33,8 +33,17 @@ class MultipleImage extends MultipleFile
 
         $this->callInterventionMethods($image->getRealPath());
 
-        return tap($this->upload($image), function () {
+        /* return tap($this->upload($image), function () {
             $this->name = null;
-        });
+        }); */
+
+        /* Copied from single image prepare section and made necessary changes so the return 
+        value is same as before, but now thumbnails are saved to the disk as well. */
+
+        $path = $this->upload($image);
+        $this->uploadAndDeleteOriginalThumbnail($image);
+        $this->name = null;
+
+        return $path;
     }
 }


### PR DESCRIPTION
== FIXES ==
Refactored thumbnail delete logic into separate method in  src/Form/Field/ImageField.php

Added thumbnails  loop  when deleting the image field file in   src/Form/Field/MultipleFile.php

Implemented same logic as single Image field prepare without changing return value in  src/Form/Field/MultipleImage.php