### PR TITLE
解决当详情页使用grid时快速创建请求地址为当前网址的问题

### DIFF
--- a/src/Grid/Tools/QuickCreate.php
+++ b/src/Grid/Tools/QuickCreate.php
@@ -231,7 +231,7 @@ class QuickCreate implements Renderable
 
     protected function script()
     {
-        $url = request()->url();
+        $url = $this->parent->resource();
 
         $script = <<<SCRIPT
 


### PR DESCRIPTION
解决：https://github.com/z-song/laravel-admin/issues/5018