### PR TITLE
修复 Laravel-Excel v3.* 导出excel为空bug

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -1072,13 +1072,13 @@ class Grid
      */
     public function render()
     {
-        $this->handleExportRequest(true);
-
         try {
             $this->build();
         } catch (\Exception $e) {
             return Handler::renderException($e);
         }
+
+        $this->handleExportRequest(true);
 
         $this->callRenderingCallback();
 


### PR DESCRIPTION
基于laravel-admin1.7.6版本升级到1.8.6版本后，使用第三方导出功能（ 文档推荐 Laravel-Excel v3.* ）出现程序没有走到第三方自定义的excel逻辑中，导出的excel为空。