### PR TITLE
 在 quick create 中使用 serializeArray

### DIFF
--- a/resources/views/table/quick-create/form.blade.php
+++ b/resources/views/table/quick-create/form.blade.php
@@ -36,7 +36,7 @@
         $.ajax({
             url: '{{ request()->url() }}',
             type: 'POST',
-            data: $(this).serialize(),
+            data: $(this).serializeArray(),
         }).done(function (data, textStatus, jqXHR) {
             if (data.status) {
                 $.admin.reload(data.message);


### PR DESCRIPTION
直接用serialize提交post会没有数据，但是serializeArray就不会，具体原因不明。