### PR TITLE
Grid filter 列过滤的reset按钮功能无效

### DIFF
--- a/src/Grid/Column/CheckFilter.php
+++ b/src/Grid/Column/CheckFilter.php
@@ -115,7 +115,7 @@ HTML;
         <li class="divider"></li>
         <li class="text-right">
             <button class="btn btn-sm btn-flat btn-primary pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
-            <span><a href="{$this->getFormAction()}" class="btn btn-sm btn-flat btn-default"><i class="fa fa-undo"></i></a></span>
+			<span><a href="{$this->getFormAction()}" class="btn btn-sm btn-flat btn-default"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>
 </form>

--- a/src/Grid/Column/CheckFilter.php
+++ b/src/Grid/Column/CheckFilter.php
@@ -115,7 +115,7 @@ HTML;
         <li class="divider"></li>
         <li class="text-right">
             <button class="btn btn-sm btn-flat btn-primary pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
-            <button class="btn btn-sm btn-flat btn-default" type="reset" data-loading-text="..."><i class="fa fa-undo"></i></button>
+            <span><a href="{$this->getFormAction()}" class="btn btn-sm btn-flat btn-default"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>
 </form>

--- a/src/Grid/Column/CheckFilter.php
+++ b/src/Grid/Column/CheckFilter.php
@@ -115,7 +115,7 @@ HTML;
         <li class="divider"></li>
         <li class="text-right">
             <button class="btn btn-sm btn-flat btn-primary pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
-			<span><a href="{$this->getFormAction()}" class="btn btn-sm btn-flat btn-default"><i class="fa fa-undo"></i></a></span>
+            <span><a href="{$this->getFormAction()}" class="btn btn-sm btn-flat btn-default"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>
 </form>

--- a/src/Grid/Column/InputFilter.php
+++ b/src/Grid/Column/InputFilter.php
@@ -112,7 +112,7 @@ SCRIPT;
         <li class="text-right">
             <button class="btn btn-sm btn-flat btn-primary column-filter-submit pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
             <button class="btn btn-sm btn-flat btn-default column-filter-all" data-loading-text="..."><i class="fa fa-undo"></i></button>
-			<span><a href="{$this->getFormAction()}" class="btn btn-sm btn-default btn-flat column-filter-all"><i class="fa fa-undo"></i></a></span>
+            <span><a href="{$this->getFormAction()}" class="btn btn-sm btn-default btn-flat column-filter-all"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>
     </form>

--- a/src/Grid/Column/InputFilter.php
+++ b/src/Grid/Column/InputFilter.php
@@ -112,6 +112,7 @@ SCRIPT;
         <li class="text-right">
             <button class="btn btn-sm btn-flat btn-primary column-filter-submit pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
             <button class="btn btn-sm btn-flat btn-default column-filter-all" data-loading-text="..."><i class="fa fa-undo"></i></button>
+			<span><a href="{$this->getFormAction()}" class="btn btn-sm btn-default btn-flat column-filter-all"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>
     </form>

--- a/src/Grid/Column/RangeFilter.php
+++ b/src/Grid/Column/RangeFilter.php
@@ -109,7 +109,7 @@ SCRIPT;
         <li class="text-right">
             <button class="btn btn-sm btn-primary btn-flat column-filter-submit pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
             <button class="btn btn-sm btn-default btn-flat column-filter-all" data-loading-text="..."><i class="fa fa-undo"></i></button>
-			<span><a href="{$this->getFormAction()}" class="btn btn-sm btn-default btn-flat column-filter-all"><i class="fa fa-undo"></i></a></span>
+            <span><a href="{$this->getFormAction()}" class="btn btn-sm btn-default btn-flat column-filter-all"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>
     </form>

--- a/src/Grid/Column/RangeFilter.php
+++ b/src/Grid/Column/RangeFilter.php
@@ -109,6 +109,7 @@ SCRIPT;
         <li class="text-right">
             <button class="btn btn-sm btn-primary btn-flat column-filter-submit pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
             <button class="btn btn-sm btn-default btn-flat column-filter-all" data-loading-text="..."><i class="fa fa-undo"></i></button>
+			<span><a href="{$this->getFormAction()}" class="btn btn-sm btn-default btn-flat column-filter-all"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>
     </form>


### PR DESCRIPTION
如：$grid->column('name','赠品名称')->filter('like'); 点击列过滤弹出的重置按钮点击达不到预期效果， 其效果等同于submit， 而不是reset。
源码：` <button class="btn btn-sm btn-flat btn-default column-filter-all" data-loading-text="..."><i class="fa fa-undo"></i></button>`


优化方法1：button标签添加 type='reset' (CheckFilter中有type设置， 其它两个类没有 )。 但是该方式依旧不能很好清除用户输入。
优化方法2：使用a标签代替。
`<a href="{$this->getFormAction()}" class="btn btn-sm btn-flat btn-default"><i class="fa fa-undo"></i></a>`。 
其做法参考于“重置”按钮
![image](https://user-images.githubusercontent.com/13361366/98800173-00d46a00-244b-11eb-880c-d29911c75d1b.png)

之所以在a标签外再套一个span， 是因为css作用冲突偏移（.dropdown-menu>li>a{ }  改样式作用级别比a标签的class高）


