### PR TITLE
select2+bootstrap modal不能正常使用“搜索聚焦”；action script会被多次渲染

### DIFF
--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -130,22 +130,23 @@ abstract class Action implements Renderable
     public function selector($prefix)
     {
         if (is_null($this->selector)) {
-            return static::makeSelector(get_called_class().spl_object_id($this), $prefix);
+            return static::makeSelector($prefix);
         }
 
         return $this->selector;
     }
 
     /**
-     * @param string $class
      * @param string $prefix
      *
      * @return string
      */
-    public static function makeSelector($class, $prefix)
+    public static function makeSelector($prefix)
     {
+        $class = get_called_class();
+
         if (!isset(static::$selectors[$class])) {
-            static::$selectors[$class] = uniqid($prefix).mt_rand(1000, 9999);
+            static::$selectors[$class] = $prefix . strtolower(class_basename($class));
         }
 
         return static::$selectors[$class];

--- a/src/Actions/Interactor/Form.php
+++ b/src/Actions/Interactor/Form.php
@@ -525,7 +525,7 @@ class Form extends Interactor
         var modalId = $(this).attr('modal');
         Object.assign(data, {$parameters});
         {$this->action->actionScript()}
-		$('#'+modalId).removeAttr('tabindex').modal('show');
+        $('#'+modalId).removeAttr('tabindex').modal('show');
         $('#'+modalId+' form').off('submit').on('submit', function (e) {
             e.preventDefault();
             var form = this;

--- a/src/Actions/Interactor/Form.php
+++ b/src/Actions/Interactor/Form.php
@@ -525,7 +525,7 @@ class Form extends Interactor
         var modalId = $(this).attr('modal');
         Object.assign(data, {$parameters});
         {$this->action->actionScript()}
-        $('#'+modalId).modal('show');
+		$('#'+modalId).removeAttr('tabindex').modal('show');
         $('#'+modalId+' form').off('submit').on('submit', function (e) {
             e.preventDefault();
             var form = this;

--- a/src/Grid/Column/InputFilter.php
+++ b/src/Grid/Column/InputFilter.php
@@ -111,7 +111,6 @@ SCRIPT;
         <li class="divider"></li>
         <li class="text-right">
             <button class="btn btn-sm btn-flat btn-primary column-filter-submit pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
-            <button class="btn btn-sm btn-flat btn-default column-filter-all" data-loading-text="..."><i class="fa fa-undo"></i></button>
             <span><a href="{$this->getFormAction()}" class="btn btn-sm btn-default btn-flat column-filter-all"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>

--- a/src/Grid/Column/RangeFilter.php
+++ b/src/Grid/Column/RangeFilter.php
@@ -108,7 +108,6 @@ SCRIPT;
         <li class="divider"></li>
         <li class="text-right">
             <button class="btn btn-sm btn-primary btn-flat column-filter-submit pull-left" data-loading-text="{$this->trans('search')}..."><i class="fa fa-search"></i>&nbsp;&nbsp;{$this->trans('search')}</button>
-            <button class="btn btn-sm btn-default btn-flat column-filter-all" data-loading-text="..."><i class="fa fa-undo"></i></button>
             <span><a href="{$this->getFormAction()}" class="btn btn-sm btn-default btn-flat column-filter-all"><i class="fa fa-undo"></i></a></span>
         </li>
     </ul>

--- a/src/Widgets/Form.php
+++ b/src/Widgets/Form.php
@@ -170,7 +170,7 @@ class Form implements Renderable
     }
 
     /**
-     * @return array
+     * @return $this
      */
     public function confirm($message)
     {


### PR DESCRIPTION
1、select2+bootstrap modal不能正常使用“搜索聚焦”:
批量操作类XxxBatchAction声明了form方法，其效果是点击”批量设置按钮“，弹出模态框， 如果模态框中粗存在select2的下拉， 则默认的搜索聚焦失效。
![image](https://user-images.githubusercontent.com/13361366/100992303-fc552a00-358e-11eb-8010-980a4a2ceb8b.png)
2、action script会被多次渲染
![image](https://user-images.githubusercontent.com/13361366/100993387-50acd980-3590-11eb-8437-32c1ab109e91.png)

因为每次调用\Encore\Admin\Actions\Action::selector()方法，都会生成唯一的字符串。那么生成脚本时
```
    protected function addScript()
    {
        if (!is_null($this->interactor)) {
            return $this->interactor->addScript();
        }

        $parameters = json_encode($this->parameters());

        $script = <<<SCRIPT

(function ($) {
    $('{$this->selector($this->selectorPrefix)}').off('{$this->event}').on('{$this->event}', function() {
        var data = $(this).data();
        var target = $(this);
        Object.assign(data, {$parameters});
        {$this->actionScript()}
        {$this->buildActionPromise()}
        {$this->handleActionPromise()}
    });
})(jQuery);

SCRIPT;

        Admin::script($script);
    }
```
最后一行调用的 Admin::script($script);  不能unique过滤掉。其结果就是Grid有多少列数据， 就有多少个delete的绑定事件被渲染。 况且从\Encore\Admin\Actions\Action::selector() 方法名的命名看， 更合理的应该是返回通用的 ’css class‘， 而不是唯一 ’css ID‘
