### PR TITLE
Add Relation ignoring functionality

### DIFF
--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -96,8 +96,8 @@ abstract class AbstractFilter
     /**
      * @var bool
      */
-	protected $ignoreRelation = false;
-	
+    protected $ignoreRelation = false;
+
     /**
      * AbstractFilter constructor.
      *
@@ -269,9 +269,9 @@ abstract class AbstractFilter
      */
     public function ignoreRelation($ignore = true)
     {
-		$this->ignoreRelation = $ignore;
+        $this->ignoreRelation = $ignore;
 
-		return $this;
+        return $this;
     }
 
     /**
@@ -476,9 +476,9 @@ abstract class AbstractFilter
      */
     protected function buildCondition()
     {
-		if($this->ignoreRelation) {
-			return [$this->query => func_get_args()];
-		}
+        if ($this->ignoreRelation) {
+            return [$this->query => func_get_args()];
+        }
 
         $column = explode('.', $this->column);
 
@@ -557,6 +557,6 @@ abstract class AbstractFilter
             return $this->presenter()->{$method}(...$params);
         }
 
-        throw new \Exception('Method "'.$method.'" not exists.');
+        throw new \Exception('Method "' . $method . '" not exists.');
     }
 }

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -557,6 +557,6 @@ abstract class AbstractFilter
             return $this->presenter()->{$method}(...$params);
         }
 
-        throw new \Exception('Method "' . $method . '" not exists.');
+        throw new \Exception('Method "'.$method.'" not exists.');
     }
 }

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -94,6 +94,11 @@ abstract class AbstractFilter
     protected $ignore = false;
 
     /**
+     * @var bool
+     */
+	protected $ignoreRelation = false;
+	
+    /**
      * AbstractFilter constructor.
      *
      * @param $column
@@ -255,6 +260,18 @@ abstract class AbstractFilter
         $this->ignore = true;
 
         return $this;
+    }
+
+    /**
+     * Ignore relation when using table.column in filter column.
+     *
+     * @return AbstractFilter
+     */
+    public function ignoreRelation($ignore = true)
+    {
+		$this->ignoreRelation = $ignore;
+
+		return $this;
     }
 
     /**
@@ -459,6 +476,10 @@ abstract class AbstractFilter
      */
     protected function buildCondition()
     {
+		if($this->ignoreRelation) {
+			return [$this->query => func_get_args()];
+		}
+
         $column = explode('.', $this->column);
 
         if (count($column) == 1) {


### PR DESCRIPTION
Sometimes we need to filter by joined table column in the grid.
For example:
```
$grid->model()->join('tbl', 'tbl.id', '=', 'tbl1.id');
...
$filter->in('tbl.id')->options([1 => 'foo', 2 => 'bar']);
```
With this syntax it was searching for `tbl` relation.

If you use `ignoreRelation()` method it willn't look for `tbl` relation and will directly filter by given column.

```
$grid->model()->join('tbl', 'tbl.id', '=', 'tbl1.id');
...
$filter->in('tbl.id')->ignoreRelation()->options([1 => 'foo', 2 => 'bar']);
```