### PR TITLE
关系关系排序isRelation判断bug修复

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -526,7 +526,7 @@ class Model
 
         $columnNameContainsDots = Str::contains($columnName, '.');
         $isRelation = $this->queries->contains(function ($query) use ($columnName) {
-            return $query['method'] === 'with' && in_array($columnName, $query['arguments'], true);
+            return $query['method'] === 'with' && Str::contains($columnName, $query['arguments']);
         });
         if ($columnNameContainsDots === true && $isRelation) {
             $this->setRelationSort($columnName);


### PR DESCRIPTION
$query['arguments']里面存的是关联关系名，columnName里面是关联关系名加排序字段，应该判断包含，不是判断相等