### PR TITLE
更换flatpickr cdn源 提高加载速度

### DIFF
--- a/src/Form/Field/DateMultiple.php
+++ b/src/Form/Field/DateMultiple.php
@@ -13,7 +13,7 @@ class DateMultiple extends Text
     protected static $js = [
         'https://cdn.jsdelivr.net/npm/flatpickr',
         'https://cdn.jsdelivr.net/npm/shortcut-buttons-flatpickr@0.1.0/dist/shortcut-buttons-flatpickr.min.js',
-        'https://npmcdn.com/flatpickr@4.6.6/dist/l10n/zh.js',
+        'https://cdn.jsdelivr.net/npm/flatpickr@4.6.9/dist/l10n/zh.js',
 
     ];
 


### PR DESCRIPTION
原先flatpickr的js npmcdn源的速度过慢导致网站加载变慢变卡，更换成jsdelivr的cdn源。