### PR TITLE
fix: inline-edit passes error value to model

### DIFF
--- a/resources/views/grid/inline-edit/switch.blade.php
+++ b/resources/views/grid/inline-edit/switch.blade.php
@@ -9,7 +9,7 @@
         offColor: '{{ $states['off']['color'] }}',
         onSwitchChange: function(event, state){
 
-            $(this).val(state ? 'on' : 'off');
+            $(this).val(state ? {{ $states['on']['value'] }} : {{ $states['off']['value'] }});
 
             var key = $(this).data('key');
             var value = $(this).val();


### PR DESCRIPTION
``` php
$states = [
        'on'  => ['value' => 0, 'text' => '正常', 'color' => 'primary'],
        'off' => ['value' => 1, 'text' => '停用', 'color' => 'danger'],
];
```
Field for this value accept 'Integer' only, model()->save() did nothing for value 'on' and 'off'.