### PR TITLE
当 form 参数形式为'驼峰.字段名'时，获取不到字段的值

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -192,6 +192,8 @@ class Form implements Renderable
         $this->builder->setMode(Builder::MODE_EDIT);
         $this->builder->setResourceId($id);
 
+        $this->setRelationFieldSnakeAttributes();
+
         $this->setFieldValue($id);
 
         return $this;
@@ -1006,6 +1008,34 @@ class Form implements Renderable
 
         $this->fields()->each(function (Field $field) use ($values) {
             $field->setOriginal($values);
+        });
+    }
+
+    /**
+     * Determine relational column needs to be snaked.
+     *
+     * @return void
+     */
+    protected function setRelationFieldSnakeAttributes()
+    {
+        $relations = $this->getRelations();
+
+        $this->fields()->each(function (Field $field) use ($relations) {
+            if ($field->getSnakeAttributes()) {
+                return;
+            }
+
+            $column = $field->column();
+
+            $column = is_array($column) ? head($column) : $column;
+
+            list($relation) = explode('.', $column);
+
+            if (!in_array($relation, $relations)) {
+                return;
+            }
+
+            $field->setSnakeAttributes($this->model::$snakeAttributes);
         });
     }
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -247,6 +247,13 @@ class Field implements Renderable
     protected $callback;
 
     /**
+     * column is snake-casing attributes.
+     *
+     * @var bool
+     */
+    protected $snakeAttributes = false;
+
+    /**
      * @var bool
      */
     public $isJsonType = false;
@@ -380,6 +387,42 @@ class Field implements Renderable
     }
 
     /**
+     * Set snake attributes to the field.
+     *
+     * @param bool $snakeAttributes
+     *
+     * @return $this
+     */
+    public function setSnakeAttributes($snakeAttributes)
+    {
+        $this->snakeAttributes = $snakeAttributes;
+
+        return $this;
+    }
+
+    /**
+     * Get snake attributes of the field.
+     *
+     * @return bool
+     */
+    public function getSnakeAttributes()
+    {
+        return $this->snakeAttributes;
+    }
+
+    /**
+     * Determine if a column needs to be snaked.
+     *
+     * @param string|array $column
+     *
+     * @return string|array
+     */
+    protected function columnShouldSnaked($column)
+    {
+        return $this->getSnakeAttributes() ? Str::snake($column) : $column;
+    }
+
+    /**
      * Fill data to the field.
      *
      * @param array $data
@@ -392,13 +435,13 @@ class Field implements Renderable
 
         if (is_array($this->column)) {
             foreach ($this->column as $key => $column) {
-                $this->value[$key] = Arr::get($data, Str::snake($column));
+                $this->value[$key] = Arr::get($data, $this->columnShouldSnaked($column));
             }
 
             return;
         }
 
-        $this->value = Arr::get($data, Str::snake($this->column));
+        $this->value = Arr::get($data, $this->columnShouldSnaked($this->column));
 
         $this->formatValue();
     }

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -392,7 +392,7 @@ class Field implements Renderable
 
         if (is_array($this->column)) {
             foreach ($this->column as $key => $column) {
-                $this->value[$key] = Arr::get($data, $column);
+                $this->value[$key] = Arr::get($data, Str::snake($column));
             }
 
             return;

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -398,7 +398,7 @@ class Field implements Renderable
             return;
         }
 
-        $this->value = Arr::get($data, $this->column);
+        $this->value = Arr::get($data, Str::snake($this->column));
 
         $this->formatValue();
     }


### PR DESCRIPTION
主要是修复了如下代码在 `edit` 页面的时候获取不到值：

```
$form->xxx('fooBar.field', __('字段')) // xxx 代表 form 的函数

$form->range('fooBar.field1',  'fooBar.field2', __('字段')) 
```