### PR TITLE
fix: inline-edit passes wrong value to model

### DIFF
--- a/resources/views/grid/inline-edit/switch-group.blade.php
+++ b/resources/views/grid/inline-edit/switch-group.blade.php
@@ -13,7 +13,7 @@
         offColor: '{{ $states['off']['color'] }}',
         onSwitchChange: function(event, state){
 
-            $(this).val(state ? 'on' : 'off');
+            $(this).val(state ? {{ $states['on']['value'] }} : {{ $states['off']['value'] }});
 
             var key = $(this).data('key');
             var value = $(this).val();


### PR DESCRIPTION
The SwitchGroup component has the same problem with PR #5304 as switch.