### PR TITLE
Groupping support for checkbox options

### DIFF
--- a/resources/views/form/checkbox.blade.php
+++ b/resources/views/form/checkbox.blade.php
@@ -15,6 +15,28 @@
 
         @include('admin::form.error')
 
+        @if($groups)
+
+        @foreach($groups as $group => $options)
+
+            <p style="{{ $canCheckAll ? 'margin: 15px 0 0 0;' : 'margin: 7px 0 0 0;' }}padding-bottom: 5px;border-bottom: 1px solid #eee;display: inline-block;">{{ $group }}</p>
+
+            @foreach($options as $option => $label)
+
+            <div class="checkbox icheck">
+
+                <label>
+                    <input type="checkbox" name="{{$name}}[]" value="{{$option}}" class="{{$class}}" {{ false !== array_search($option, array_filter(old($column, $value ?? []))) || ($value === null && in_array($option, $checked)) ?'checked':'' }} {!! $attributes !!} />&nbsp;{{$label}}&nbsp;&nbsp;
+                </label>
+
+            </div>
+
+            @endforeach
+
+        @endforeach
+
+        @else
+
         @foreach($options as $option => $label)
 
             {!! $inline ? '<span class="icheck">' : '<div class="checkbox icheck">' !!}
@@ -26,6 +48,8 @@
             {!! $inline ? '</span>' :  '</div>' !!}
 
         @endforeach
+
+        @endif
 
         <input type="hidden" name="{{$name}}[]">
 

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -126,7 +126,7 @@ class Checkbox extends MultipleSelect
             'checked'     => $this->checked,
             'inline'      => $this->inline,
             'canCheckAll' => $this->canCheckAll,
-            'groups'      => $this->groups
+            'groups'      => $this->groups,
         ]);
 
         if ($this->canCheckAll) {

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -10,6 +10,8 @@ class Checkbox extends MultipleSelect
 
     protected $canCheckAll = false;
 
+    protected $groups = null;
+
     protected static $css = [
         '/vendor/laravel-admin/AdminLTE/plugins/iCheck/all.css',
     ];
@@ -53,6 +55,20 @@ class Checkbox extends MultipleSelect
     public function canCheckAll()
     {
         $this->canCheckAll = true;
+
+        return $this;
+    }
+
+    /**
+     * Set chekbox groups.
+     *
+     * @param array
+     *
+     * @return $this
+     */
+    public function groups($groups = [])
+    {
+        $this->groups = $groups;
 
         return $this;
     }
@@ -110,6 +126,7 @@ class Checkbox extends MultipleSelect
             'checked'     => $this->checked,
             'inline'      => $this->inline,
             'canCheckAll' => $this->canCheckAll,
+            'groups'      => $this->groups
         ]);
 
         if ($this->canCheckAll) {


### PR DESCRIPTION
Groupping feature like select optgroup.

Example:
```
$form->checkbox('group1', __('Groupped Checkbox 1'))
    ->groups(
        [
            'Group 1' => [
                'key1' => 'Value 1',
                'key2' => 'Value 2',
            ],
            'Group 2' => [
                'key3' => 'Value 3',
                'key4' => 'Value 4',
                'key5' => 'Value 5',
            ],
        ]
    );

$form->checkbox('group2', __('Groupped Checkbox 2'))
    ->groups(
        [
            'Group 1' => [
                'key1' => 'Value 1',
                'key2' => 'Value 2',
            ],
            'Group 2' => [
                'key3' => 'Value 3',
                'key4' => 'Value 4',
                'key5' => 'Value 5',
            ],
        ]
    )
    ->canCheckAll();
```

Form output:
![image](https://user-images.githubusercontent.com/8195419/116813958-25d6a980-ab5f-11eb-9aee-59be4b9e8f87.png)
