### PR TITLE
Fixed to allow many inputmask type in between filter.

### DIFF
--- a/resources/views/filter/between.blade.php
+++ b/resources/views/filter/between.blade.php
@@ -2,9 +2,9 @@
     <label class="col-sm-2 control-label">{{$label}}</label>
     <div class="col-sm-8" style="width: 390px">
         <div class="input-group input-group-sm">
-            <input type="text" class="form-control" placeholder="{{$label}}" name="{{$name['start']}}" value="{{ request()->input("{$column}.start", \Illuminate\Support\Arr::get($value, 'start')) }}">
+            <input type="text" class="form-control {{$id['start']}}" placeholder="{{$label}}" name="{{$name['start']}}" value="{{ request()->input("{$column}.start", \Illuminate\Support\Arr::get($value, 'start')) }}">
             <span class="input-group-addon" style="border-left: 0; border-right: 0;">-</span>
-            <input type="text" class="form-control" placeholder="{{$label}}" name="{{$name['end']}}" value="{{ request()->input("{$column}.end", \Illuminate\Support\Arr::get($value, 'end')) }}">
+            <input type="text" class="form-control {{$id['end']}}" placeholder="{{$label}}" name="{{$name['end']}}" value="{{ request()->input("{$column}.end", \Illuminate\Support\Arr::get($value, 'end')) }}">
         </div>
     </div>
 </div>

--- a/src/Grid/Filter/Presenter/Text.php
+++ b/src/Grid/Filter/Presenter/Text.php
@@ -164,7 +164,7 @@ class Text extends Presenter
 
         if (is_array($this->filter->getId())) {
             $ids = $this->filter->getId();
-        }else{
+        } else {
             $ids[] = $this->filter->getId();
         }
 

--- a/src/Grid/Filter/Presenter/Text.php
+++ b/src/Grid/Filter/Presenter/Text.php
@@ -162,7 +162,15 @@ class Text extends Presenter
     {
         $options = json_encode($options);
 
-        Admin::script("$('#{$this->filter->getFilterBoxId()} input.{$this->filter->getId()}').inputmask($options);");
+        if (is_array($this->filter->getId())) {
+            $ids = $this->filter->getId();
+        }else{
+            $ids[] = $this->filter->getId();
+        }
+
+        foreach ($ids as $id) {
+            Admin::script("$('#{$this->filter->getFilterBoxId()} input.{$id}').inputmask($options);");
+        }
 
         $this->icon = $icon;
 

--- a/src/Grid/Filter/Presenter/Text.php
+++ b/src/Grid/Filter/Presenter/Text.php
@@ -162,11 +162,7 @@ class Text extends Presenter
     {
         $options = json_encode($options);
 
-        if (is_array($this->filter->getId())) {
-            $ids = $this->filter->getId();
-        } else {
-            $ids[] = $this->filter->getId();
-        }
+        $ids = (array) $this->filter->getId();
 
         foreach ($ids as $id) {
             Admin::script("$('#{$this->filter->getFilterBoxId()} input.{$id}').inputmask($options);");


### PR DESCRIPTION
Hello there,
I modified the biteween filter to allow integer(), decimal(), currency(), etc.

`$filter->between('amount',__('数量'))->integer();`
`$filter->between('distance',__('距離'))->decimal();`
`$filter->between('price',__('価格'))->currency();`

Regards, Takkkken