### PR TITLE
Make sure `$field` is valid

### DIFF
--- a/src/Form/EmbeddedForm.php
+++ b/src/Form/EmbeddedForm.php
@@ -181,7 +181,7 @@ class EmbeddedForm
             return in_array($key, (array) $field->column());
         });
 
-        if (method_exists($field, 'prepare')) {
+        if ($field && method_exists($field, 'prepare')) {
             return $field->prepare($record);
         }
 


### PR DESCRIPTION
当同时使用 `$form->when()` 和 `$form->embeds()` 的时候有可能会出现此处 `$field` 为 null 的情况, 兼容一下.