### PR TITLE
Fix validation error, unable to submit repeatedly

### DIFF
--- a/src/Actions/Interactor/Form.php
+++ b/src/Actions/Interactor/Form.php
@@ -617,6 +617,7 @@ PROMISE;
                     if (data.status === true) {
                         $('#'+modalId).modal('hide');
                     }
+                    $(':submit', '#'+modalId).button('reset');
                 },
                 error:function(request){
                     reject(request);


### PR DESCRIPTION
## Grid 自定义操作模态框Form，添加验证规则时，错误的数据提交，无法继续正常提交  
## 场景还原
```
    public function form()
    {
        ....
        $this->radio('status', __('admin.status'))->options($status)->rules('required');
        $this->textarea('login_remark', __('admin.Login remark'))->rules('required');
    }
```
设置验证规则后，错误的数据，按钮一直显示loading，且无法继续第二次提交; 
![image](https://user-images.githubusercontent.com/40051171/130558744-f4ddc3d9-a3de-41a0-b1c9-9cabc9401325.png)
## 原因
ajax 验证错误后没有重置button;
## Fix 
```
// Encore\Admin\Actions\Interactor\Form.php
 protected function buildGeneralActionPromise()
    {
       ....
            $.ajax({
                method: '{$this->action->getMethod()}',
                url: '{$this->action->getHandleRoute()}',
                data: formData,
                cache: false,
                contentType: false,
                processData: false,
                success: function (data) {
                    resolve([data, target]);
                    if (data.status === true) {
                        $('#'+modalId).modal('hide');
                    }
                     // 还原按钮
                    $(':submit', '#'+modalId).button('reset');
                },
                error:function(request){
                    reject(request);
                }
            });
          ....
    }
```