### PR TITLE
修护在模型全局作用域下，模型表格自定义操作无法取消全局作用域问题

### DIFF
--- a/src/Actions/RowAction.php
+++ b/src/Actions/RowAction.php
@@ -115,12 +115,15 @@ abstract class RowAction extends GridAction
         }
 
         $modelClass = str_replace('_', '\\', $request->get('_model'));
-
+        $modelObj = new $modelClass();
+        if (method_exists($this, 'modelBooted')) {
+            $modelObj = $this->modelBooted($modelObj);
+        }
         if ($this->modelUseSoftDeletes($modelClass)) {
-            return $modelClass::withTrashed()->findOrFail($key);
+            return $modelObj->withTrashed()->findOrFail($key);
         }
 
-        return $modelClass::findOrFail($key);
+        return $modelObj->findOrFail($key);
     }
 
     public function display($value)
@@ -148,5 +151,17 @@ abstract class RowAction extends GridAction
             $this->getElementClass(),
             $this->asColumn ? $this->display($this->row($this->column->getName())) : $this->name()
         );
+    }
+
+    /**
+     * model booted function
+     * @param $model
+     * @return mixed
+     * @author ChenDasheng
+     * @created 2021/8/29 12:02
+     */
+    public function modelBooted($model)
+    {
+        return $model;
     }
 }


### PR DESCRIPTION
## 前言
实在有点忙，就用中文编写问题和描述了，望国外友人们谅解；
## 场景复现
模型中加入全局作用域后，模型表格自定义操作无法取消全局作用域后，使用时会抛出500错误，场景如下：
用户有审核机制，我需要查询通过审核的用户;
```php
    // App\Models\User.php
    protected static function boot()
    {
        parent::boot();
        static::addGlobalScope('status', function (Builder $builder) {
            return $builder->where('status', self::STATUS_PASS); //查询通过审核的用户
        });
    }
```
在用户列表中我需要去审核;  
由于模型中在实例化阶段没有withoutGlobalScope()方法，导致模型无法获取,抛出500错误;
```php
    //App\Admin\Actions\Users\Examine.php
    public function handle(Model $model, Request $request)
    {
        $status = $request->get('status');
        $login_remark = $request->get('login_remark');
        $model->status = $status;
        $model->login_remark = $login_remark;
        try {
            $model->save();
        } catch (\Exception $exception) {
            return $this->response()->error('系统错误，操作失败！')->refresh();
        }
        return $this->response()->success('操作成功！')->refresh();
    }

```

## 修护问题
```php
//Encore\Admin\Actions\RowAction.php;

public function retrieveModel(Request $request){
    ...
    $modelClass = str_replace('_', '\\', $request->get('_model'));
    $modelObj = new $modelClass();
    if (method_exists($this, 'modelBooted')) {
        $modelObj = $this->modelBooted($modelObj);
    }
    if ($this->modelUseSoftDeletes($modelClass)) {
        return $modelObj->withTrashed()->findOrFail($key);
    }
    ...
}

//需要在自定义行中加入modelBooted 可以取消全局作用域或软删除功能
//App\Admin\Actions\Users\Examine.php

public function modelBooted($model)
{
    return $model->withoutGlobalScope('status');
}
```

## 后记
有更加优雅的方法更好~