### PR TITLE
Permission middleware控制路由的權限功能無法使用

### DIFF
--- a/src/Middleware/Permission.php
+++ b/src/Middleware/Permission.php
@@ -29,7 +29,7 @@ class Permission
             return $next($request);
         }
 
-        if (!Admin::user() || !empty($args) || $this->shouldPassThrough($request)) {
+        if (!Admin::user() || $this->shouldPassThrough($request)) {
             return $next($request);
         }
 

--- a/src/Middleware/Permission.php
+++ b/src/Middleware/Permission.php
@@ -70,9 +70,8 @@ class Permission
             throw new \InvalidArgumentException("Invalid permission method [$method].");
         }
 
-        call_user_func_array([Checker::class, $method], [$args]);
+        return call_user_func_array([Checker::class, $method], [$args]);
 
-        return true;
     }
 
     /**


### PR DESCRIPTION
修改以下兩點：

(1)在`class Encore\Admin\Middleware\Permission`中，`if (!Admin::user() || !empty($args) || $this->shouldPassThrough($request))`的「` !empty($args)`」導致無法進入`if ($this->checkRoutePermission($request))`，因此`Permission middleware`的額外參數無法作用

(2)`function checkRoutePermission`沒有正確回傳真假值

如有錯誤，再麻煩更正，謝謝！