### PR TITLE
Fixed a warning in PHP 8.1.

### DIFF
--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -618,7 +618,7 @@ class Column
     /**
      * Convert characters to HTML entities recursively.
      *
-     * @param array|string $item
+     * @param array|string|null $item
      *
      * @return mixed
      */
@@ -626,10 +626,10 @@ class Column
     {
         if (is_array($item)) {
             array_walk_recursive($item, function (&$value) {
-                $value = htmlentities($value);
+                $value = htmlentities($value ?? '');
             });
         } else {
-            $item = htmlentities($item);
+            $item = htmlentities($item ?? '');
         }
 
         return $item;

--- a/src/Grid/Concerns/CanHidesColumns.php
+++ b/src/Grid/Concerns/CanHidesColumns.php
@@ -70,7 +70,9 @@ trait CanHidesColumns
      */
     protected function getVisibleColumnsFromQuery()
     {
-        $columns = explode(',', request(ColumnSelector::SELECT_COLUMN_NAME));
+        $requestColumn = request(ColumnSelector::SELECT_COLUMN_NAME);
+
+        $columns = $requestColumn ? explode(',', $requestColumn) : [];
 
         return array_filter($columns) ?:
             array_values(array_diff($this->columnNames, $this->hiddenColumns));

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -198,7 +198,7 @@ STR;
 
         Admin::script("$('.$class').editable($options);");
 
-        $this->value = htmlentities($this->value);
+        $this->value = htmlentities($this->value ?? '');
 
         $attributes = [
             'href'       => '#',


### PR DESCRIPTION
I fixed the warnings that I encountered, although there may be others.

If the value passed to functions is null, PHP8.1 will throw a warning with functions.

`***(): Passing null to parameter #1 ($string) of type string is deprecated.`

https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg