### PR TITLE
Fix date-range field problem with Persian numbers

### DIFF
--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -50,7 +50,7 @@ class DateRange extends Field
 
     public function render()
     {
-        $this->options['locale'] = config('app.locale');
+        $this->options['locale'] = array_key_exists('locale', $this->options) ? $this->options['locale'] : config('app.locale');
 
         $startOptions = json_encode($this->options);
         $endOptions = json_encode($this->options + ['useCurrent' => false]);


### PR DESCRIPTION
Same as other date and time fields make user to be able to set custom locale for data-range field
Sometime it is required like when your locale is Persian and you want receive date numbers in English