### PR TITLE
fixed favicon method inconsistency with document and usages

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -226,7 +226,7 @@ class Admin
      *
      * @return string|void
      */
-    public function favicon($favicon = null)
+    public static function favicon($favicon = null)
     {
         if (is_null($favicon)) {
             return static::$favicon;

--- a/src/Widgets/Box.php
+++ b/src/Widgets/Box.php
@@ -62,7 +62,7 @@ class Box extends Widget implements Renderable
     /**
      * Set box content.
      *
-     * @param string $content
+     * @param string|Renderable $content
      *
      * @return $this
      */
@@ -80,7 +80,7 @@ class Box extends Widget implements Renderable
     /**
      * Set box footer.
      *
-     * @param string $footer
+     * @param string|Renderable $footer
      *
      * @return $this
      */


### PR DESCRIPTION
In documents and views, `favicon()` was used like:

```php
Admin::favicon('favicon.png');
```

```php
@if(!is_null($favicon = Admin::favicon()))
    <link rel="shortcut icon" href="{{$favicon}}">
@endif
```

However, in **Encore\Admin\Admin**, it is inconsistently designated as `public function` rather than `public static function`. It doesn't affect actual usage right now but it is an inconsistency that should be fixed.

```php
    /**
     * @param null|string $favicon
     *
     * @return string|void
     */
    public function favicon($favicon = null)
    {
        if (is_null($favicon)) {
            return static::$favicon;
        }

        static::$favicon = $favicon;
    }
```