### PR TITLE
fix: 修复使用规格选择器的 selectOne 时出现 TypeError 的问题

### DIFF
--- a/src/Grid/Concerns/HasSelector.php
+++ b/src/Grid/Concerns/HasSelector.php
@@ -53,8 +53,8 @@ trait HasSelector
 
             $values = $active[$column];
 
-            if ($selector['type'] == 'one') {
-                $values = current($values);
+            if ($selector['type'] === 'one') {
+                $values = (array)current($values);
             }
 
             if (is_null($selector['query'])) {


### PR DESCRIPTION
按照 [文档示例](https://laravel-admin.org/docs/zh/1.x/model-grid-spec-selector#%E5%9F%BA%E6%9C%AC%E4%BD%BF%E7%94%A8) 使用 **$selector->selectOne()** 时，会出现报错：

```
TypeError In Builder.php line 3265 :
```

使用代码
```php
$grid->selector(function (Grid\Tools\Selector $selector) {
    $selector->selectOne('brand', '品牌', [
        1 => '华为',
        2 => '小米',
        3 => 'OPPO',
        4 => 'vivo',
    ]);
});
```

报错截图：

![报错截图](https://user-images.githubusercontent.com/10508638/137276001-3cd0c506-f460-42e7-9ae3-e8d59ba13143.png)

