### PR TITLE
fix: 修复使用规格选择器的 selectOne 时出现 TypeError 的问题

### DIFF
--- a/src/Grid/Concerns/HasSelector.php
+++ b/src/Grid/Concerns/HasSelector.php
@@ -58,7 +58,7 @@ trait HasSelector
             }
 
             if (is_null($selector['query'])) {
-                $this->model()->whereIn($column, (array)$values);
+                $this->model()->whereIn($column, (array) $values);
             } else {
                 call_user_func($selector['query'], $this->model(), $values);
             }


### PR DESCRIPTION
### 问题：

按照 [文档示例](https://laravel-admin.org/docs/zh/1.x/model-grid-spec-selector#%E5%9F%BA%E6%9C%AC%E4%BD%BF%E7%94%A8) 使用 **$selector->selectOne()** 时，会出现报错：

```
TypeError In Builder.php line 3265 :
```

### 复现：

使用代码
```php
$grid->selector(function (Grid\Tools\Selector $selector) {
    $selector->selectOne('brand', '品牌', [
        1 => '华为',
        2 => '小米',
        3 => 'OPPO',
        4 => 'vivo',
    ]);
});
```

### 报错完整截图：

![报错截图](https://user-images.githubusercontent.com/10508638/137276001-3cd0c506-f460-42e7-9ae3-e8d59ba13143.png)

### 解决

出现报错的原因是 `\Illuminate\Database\Query\Builder::whereIn($column, $values)` 的 `$values` 只支持 `array|\Illuminate\Contracts\Support\Arrayable` 类型。遂在调用 `whereIn` 时增加类型格式化，格式化为 `array`。