### PR TITLE
Load custom CSS after all to be more customizable

### DIFF
--- a/src/Traits/HasAssets.php
+++ b/src/Traits/HasAssets.php
@@ -112,11 +112,11 @@ trait HasAssets
         static::ignoreMinify($css, $minify);
 
         if (!is_null($css)) {
-            return self::$css = array_merge(self::$css, (array) $css);
+            return self::$css = array_merge((array) $css, self::$css);
         }
 
         if (!$css = static::getMinifiedCss()) {
-            $css = array_merge(static::$css, static::baseCss());
+            $css = array_merge(static::baseCss(), static::$css);
         }
 
         $css = array_filter(array_unique($css));

--- a/src/Traits/HasAssets.php
+++ b/src/Traits/HasAssets.php
@@ -118,9 +118,9 @@ trait HasAssets
 
         if (!is_null($css)) {
             if ($appendCss) {
-                return self::$appendCss = array_merge(self::$appendCss, (array)$css);
+                return self::$appendCss = array_merge(self::$appendCss, (array) $css);
             } else {
-                return self::$css = array_merge(self::$css, (array)$css);
+                return self::$css = array_merge(self::$css, (array) $css);
             }
         }
 

--- a/src/Traits/HasAssets.php
+++ b/src/Traits/HasAssets.php
@@ -27,6 +27,11 @@ trait HasAssets
     /**
      * @var array
      */
+    public static $appendCss = [];
+
+    /**
+     * @var array
+     */
     public static $js = [];
 
     /**
@@ -107,16 +112,20 @@ trait HasAssets
      *
      * @return array|\Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public static function css($css = null, $minify = true)
+    public static function css($css = null, $minify = true, $appendCss = false)
     {
         static::ignoreMinify($css, $minify);
 
         if (!is_null($css)) {
-            return self::$css = array_merge((array) $css, self::$css);
+            if ($appendCss) {
+                return self::$appendCss = array_merge(self::$appendCss, (array)$css);
+            } else {
+                return self::$css = array_merge(self::$css, (array)$css);
+            }
         }
 
         if (!$css = static::getMinifiedCss()) {
-            $css = array_merge(static::baseCss(), static::$css);
+            $css = array_merge(static::$css, static::baseCss(), static::$appendCss);
         }
 
         $css = array_filter(array_unique($css));


### PR DESCRIPTION
Load user's custom CSS after default framework CSS to be more customizable. For example when you want change system whole fonts if custom CSS load after all it is too easy to customize while if you load user's CSS before all it is hard and you need more complicate css selector