### PR TITLE
fix when your grid have sortable relation column

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -526,8 +526,7 @@ class Model
 
         $columnNameContainsDots = Str::contains($columnName, '.');
         $isRelation = $this->queries->contains(function ($query) use ($columnName) {
-            // relationship should be camel case
-            $columnName = Str::camel(Str::before($columnName, '.'));
+            $columnName = Str::snake(Str::before($columnName, '.'));
 
             return $query['method'] === 'with' && in_array($columnName, $query['arguments'], true);
         });
@@ -579,6 +578,9 @@ class Model
         if ($this->queries->contains(function ($query) use ($relationName) {
             return $query['method'] == 'with' && in_array($relationName, $query['arguments']);
         })) {
+            if (!method_exists($this->model, $relationName)) {
+                return;
+            }
             $relation = $this->model->$relationName();
 
             $this->queries->push([


### PR DESCRIPTION
## Issue
when you  have sortable relation column, error occurs.

```
 QueryException In Connection.php line 703 :
  SQLSTATE[42S22]: Column not found: 1054 Unknown column 'JSON_EXTRACT(..., '$....')' in 'order clause' (SQL: select * from `...` order by `JSON_EXTRACT(..., '$`.`...')` desc limit 20 offset 0)
```
```
BadMethodCallException
Method Illuminate\Database\Eloquent\Collection::... does not exist. (View: /var/www/html/vendor/encore/laravel-admin/resources/views/grid/table.blade.php)
```

## problem

### 1. camel case relationship sort is not work, but snake case relationship is work.

#### not work
```
// model
    public function userInfo()
    {
        return $this->hasOne(UserInfo::class, 'user_id');
    }
```
```
// Grid/Model.php setSort
$columnName = Str::camel(Str::before($columnName, '.'));
```

#### work
```
// model
    public function user_info()
    {
        return $this->hasOne(UserInfo::class, 'user_id');
    }
```
```
// Grid/Model.php setSort
$columnName = Str::snake(Str::before($columnName, '.'));
```

### 2. bad method call

#### not work

```
// Grid/Model.php setRelationSort
$relation = $this->model->$relationName();
```

#### work

```
// Grid/Model.php setRelationSort
if (!method_exists($this->model, $relationName)) {
    return;
}
$relation = $this->model->$relationName();
```
