### PR TITLE
修复keyValue组件，在一对一关联关系中，新增、删除点击没反应的bug

### DIFF
--- a/resources/views/form/keyvalue.blade.php
+++ b/resources/views/form/keyvalue.blade.php
@@ -11,7 +11,7 @@
                 <th style="width: 75px;"></th>
             </tr>
             </thead>
-            <tbody class="kv-{{$column}}-table">
+            <tbody class="kv-{{$id}}-table">
 
             @foreach(old("{$column}.keys", ($value ?: [])) as $k => $v)
 
@@ -47,7 +47,7 @@
 
                     <td class="form-group">
                         <div>
-                            <div class="{{$column}}-remove btn btn-warning btn-sm pull-right">
+                            <div class="{{$id}}-remove btn btn-warning btn-sm pull-right">
                                 <i class="fa fa-trash">&nbsp;</i>{{ __('admin.remove') }}
                             </div>
                         </div>
@@ -60,7 +60,7 @@
                     <td></td>
                     <td></td>
                     <td>
-                        <div class="{{ $column }}-add btn btn-success btn-sm pull-right">
+                        <div class="{{ $id }}-add btn btn-success btn-sm pull-right">
                             <i class="fa fa-save"></i>&nbsp;{{ __('admin.new') }}
                         </div>
                     </td>
@@ -68,7 +68,7 @@
             </tfoot>
         </table>
     </div>
-    <template class="{{$column}}-tpl">
+    <template class="{{$id}}-tpl">
         <tr>
             <td>
                 <div class="form-group  ">
@@ -87,7 +87,7 @@
 
             <td class="form-group">
                 <div>
-                    <div class="{{$column}}-remove btn btn-warning btn-sm pull-right">
+                    <div class="{{$id}}-remove btn btn-warning btn-sm pull-right">
                         <i class="fa fa-trash">&nbsp;</i>{{ __('admin.remove') }}
                     </div>
                 </div>

--- a/src/Form/Field/KeyValue.php
+++ b/src/Form/Field/KeyValue.php
@@ -64,12 +64,12 @@ class KeyValue extends Field
     {
         $this->script = <<<SCRIPT
 
-$('.{$this->column}-add').on('click', function () {
-    var tpl = $('template.{$this->column}-tpl').html();
-    $('tbody.kv-{$this->column}-table').append(tpl);
+$('.{$this->id}-add').on('click', function () {
+    var tpl = $('template.{$this->id}-tpl').html();
+    $('tbody.kv-{$this->id}-table').append(tpl);
 });
 
-$('tbody').on('click', '.{$this->column}-remove', function () {
+$('tbody').on('click', '.{$this->id}-remove', function () {
     $(this).closest('tr').remove();
 });
 


### PR DESCRIPTION
在form表单中，使用$form->keyValue('content.keyvalue1','自定义键值对象');  
发现页面中组件用不了，点击新增、删除等按钮没有反应，也没有报js错误。 查看源码发现使用的$this->column作为class的类名，由于没有转换".",class冲突了，所以改用$this->id作为class。
本地测试
$form->keyValue('content.keyvalue1','自定义键值对象')
$form->keyValue('keyvalue1','自定义键值对象')
两种方式都正常使用