### PR TITLE
fix grid json column sortable error

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Request;
@@ -551,7 +552,7 @@ class Model
                 $method = 'orderByRaw';
                 $arguments = [$column];
             } else {
-                $column = $columnName;
+                $column = $columnNameContainsDots ? new Expression($columnName) : $columnName;
                 $method = 'orderBy';
                 $arguments = [$column, $this->sort['type']];
             }


### PR DESCRIPTION
如果grid的某一列为json，排序时会导致sql报错：
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'prefix_JSON_EXTRACT(json, '$.json_column')' in 'order clause' 
原因是json处理后的排序字段：
![image](https://user-images.githubusercontent.com/7800865/147059235-b08f1808-ba90-429e-b496-2c1f0c1ac79c.png)
会在执行时被laravelORM的Gammer转译（增加前缀和``）
所以在增加针对json字段特殊处理：
![image](https://user-images.githubusercontent.com/7800865/147059492-d23dd6b0-8974-4bbc-a315-0998650cdb13.png)

