### PR TITLE
fix declaration of Encore\Admin\Form\Field\Checkbox::groups

### DIFF
--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -66,7 +66,7 @@ class Checkbox extends MultipleSelect
      *
      * @return $this
      */
-    public function groups($groups = [])
+    public function groups(array $groups = [])
     {
         $this->groups = $groups;
 


### PR DESCRIPTION
## Env
PHP 7.0.33
Laravel 5.5
## Description
我用php7.0.33装1.8.16，刚开始我以为是版本的问题，就降了一个版本，装了1.8.15,也有这个问题。再看Requirements,是支持7.0版本的。

```txt
"Declaration of Encore\Admin\Form\Field\Checkbox::groups($groups = Array) should be compatible with Encore\Admin\Form\Field\Select::groups(array $groups)"
```
