### PR TITLE
将配置项 admin_https 的作用域限制到 /admin*

### DIFF
--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -99,7 +99,7 @@ class AdminServiceProvider extends ServiceProvider
      */
     protected function ensureHttps()
     {
-        $is_admin = \Str::startsWith(request()->getRequestUri(), '/' . ltrim(config('admin.route.prefix'), '/'));
+        $is_admin = \Str::startsWith(request()->getRequestUri(), '/'.ltrim(config('admin.route.prefix'), '/'));
         if ((config('admin.https') || config('admin.secure')) && $is_admin) {
             url()->forceScheme('https');
             $this->app['request']->server->set('HTTPS', true);

--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -99,7 +99,8 @@ class AdminServiceProvider extends ServiceProvider
      */
     protected function ensureHttps()
     {
-        if ((config('admin.https') || config('admin.secure')) && \Str::startsWith(request()->getRequestUri(), '/admin')) {
+        $is_admin = \Str::startsWith(request()->getRequestUri(), '/' . ltrim(config('admin.route.prefix'), '/'))
+        if ((config('admin.https') || config('admin.secure')) && $is_admin) {
             url()->forceScheme('https');
             $this->app['request']->server->set('HTTPS', true);
         }

--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -99,7 +99,7 @@ class AdminServiceProvider extends ServiceProvider
      */
     protected function ensureHttps()
     {
-        if (config('admin.https') || config('admin.secure')) {
+        if ((config('admin.https') || config('admin.secure')) && \Str::startsWith(request()->getRequestUri(), '/admin')) {
             url()->forceScheme('https');
             $this->app['request']->server->set('HTTPS', true);
         }

--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -99,7 +99,7 @@ class AdminServiceProvider extends ServiceProvider
      */
     protected function ensureHttps()
     {
-        $is_admin = \Str::startsWith(request()->getRequestUri(), '/' . ltrim(config('admin.route.prefix'), '/'))
+        $is_admin = \Str::startsWith(request()->getRequestUri(), '/' . ltrim(config('admin.route.prefix'), '/'));
         if ((config('admin.https') || config('admin.secure')) && $is_admin) {
             url()->forceScheme('https');
             $this->app['request']->server->set('HTTPS', true);


### PR DESCRIPTION
配置项的名称是 admin_https，那么该配置的作用域不应该超出 /admin* 的范围，即不应该去影响非后台路由，一旦这里影响了，后续想要在其他页面做 http 和 https 的兼容会很麻烦