### PR TITLE
Show validation errors when switch changed

### DIFF
--- a/resources/views/grid/inline-edit/switch.blade.php
+++ b/resources/views/grid/inline-edit/switch.blade.php
@@ -22,13 +22,24 @@
                 data: {
                     "{{ $name }}": value,
                     _token: LA.token,
-                    _method: 'PUT'
+                    _method: 'PUT',
+                    _edit_inline: true
                 },
                 success: function (data) {
                     if (data.status)
                         toastr.success(data.message);
                     else
                         toastr.warning(data.message);
+                },
+                error: function (xhr, textStatus, errorThrown) {
+                    _status = false;
+                    var data = xhr.responseJSON
+                    if (data['errors'] || data['message']) {
+                        var message = data['message'] || Object.values(data['errors']).join("\n");
+                        toastr.error(message);
+                    } else {
+                        toastr.error('Error: ' + errorThrown);
+                    }
                 },
                 complete:function(xhr,status) {
                     if (status == 'success')


### PR DESCRIPTION
When switch change has validation errors, When the state of the switch changes and there is a validation error, an empty warning appears and a JS error occurs in the console.
At the same time the visual state of the switch changes.
This commit displays an error message and does not change the visual state if an error occurs. 