### PR TITLE
Add options to date and time  filters

### DIFF
--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -316,9 +316,10 @@ abstract class AbstractFilter
      *
      * @return DateTime
      */
-    public function date()
+    public function date($options = [])
     {
-        return $this->datetime(['format' => 'YYYY-MM-DD']);
+        $options['format'] = Arr::get($options, 'format', 'YYYY-MM-DD');
+        return $this->datetime($options);
     }
 
     /**
@@ -326,9 +327,10 @@ abstract class AbstractFilter
      *
      * @return DateTime
      */
-    public function time()
+    public function time($options = [])
     {
-        return $this->datetime(['format' => 'HH:mm:ss']);
+        $options['format'] = Arr::get($options, 'format', 'HH:mm:ss');
+        return $this->datetime($options);
     }
 
     /**


### PR DESCRIPTION
Useful when you want set options like different locale on date/time filter select-box. Example:
```
$filter->date('updated_at')->date(['locale' => 'en']);
```