### PR TITLE
Fixed a hasMany field's bug when added a new form.

### DIFF
--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -326,7 +326,7 @@ class HasMany extends Field
      *
      * @return NestedForm
      */
-    protected function buildNestedForm($column, \Closure $builder, $model = null)
+    protected function buildNestedForm($column, \Closure $builder, $elementName = null, $model = null)
     {
         $form = new Form\NestedForm($column, $model);
 
@@ -334,6 +334,10 @@ class HasMany extends Field
             $form->setWidgetForm($this->form);
         } else {
             $form->setForm($this->form);
+        }
+
+        if(!is_null($elementName)){
+            $form->setKey($elementName);
         }
 
         call_user_func($builder, $form);
@@ -433,7 +437,7 @@ class HasMany extends Field
 
                 $model = $relation->getRelated()->replicate()->forceFill($data);
 
-                $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $model)
+                $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $key, $model)
                     ->fill($data);
             }
         } else {
@@ -446,7 +450,7 @@ class HasMany extends Field
 
                 $model = $relation->getRelated()->replicate()->forceFill($data);
 
-                $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $model)
+                $forms[$key] = $this->buildNestedForm($this->column, $this->builder, null, $model)
                     ->fill($data);
             }
         }

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -336,7 +336,7 @@ class HasMany extends Field
             $form->setForm($this->form);
         }
 
-        if(!is_null($elementName)){
+        if (!is_null($elementName)) {
             $form->setKey($elementName);
         }
 

--- a/src/Form/Field/Table.php
+++ b/src/Form/Field/Table.php
@@ -89,7 +89,7 @@ class Table extends HasMany
         return 'id';
     }
 
-    protected function buildNestedForm($column, \Closure $builder, $key = null)
+    protected function buildNestedForm($column, \Closure $builder, $key = null, $model = null)
     {
         $form = new NestedForm($column);
 


### PR DESCRIPTION
Hi, I always use this library.

### Problem

1. When I added a new form in hasMany field, The validation error is not displayed.
This happen on submit only the first time after added form.
2. Also, after I added some forms, submit once with a validation error and then submit again, it's reduced to only one form.

### Cause of this problem

When I added a new form, the new form's "name" attribute's value is `$relation[new_1][$column]`.
But, after on submit with validation error, the new form's "name" is `$relation[new___LA_KEY__][$column]`.

If I add some forms and submit with validation error, all forms "name" will be `$relation[new___LA_KEY__][$column]`.

1. The error is not displayed because the "name" attribute of the form has changed between when it was posted and when it was displayed.
2. Due to duplicate form "name", some forms are reduced to one.

### Solution

I have changed the following classes.

```
Encore\Admin\Form\Field\HasMany
```

I changed `HasMany::buildNestedForm` method because `NestedForm::key` property should be have changed to the correct value before `NestedForm::formatField` method was called.

#### Before
```
protected function buildNestedForm($column, \Closure $builder, $model = null)
{
    $form = new Form\NestedForm($column, $model);

    if ($this->form instanceof WidgetForm) {
        $form->setWidgetForm($this->form);
    } else {
        $form->setForm($this->form);
    }

    call_user_func($builder, $form);
```
```
protected function buildRelatedForms()
{
    omit......

    if ($values = old($this->column)) {
        foreach ($values as $key => $data) {
            if ($data[NestedForm::REMOVE_FLAG_NAME] == 1) {
                continue;
            }

            $model = $relation->getRelated()->replicate()->forceFill($data);

            $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $model)
                ->fill($data);
        }
    } else {
```

#### After
```
//Add the argument $elementName.
protected function buildNestedForm($column, \Closure $builder, $elementName = null, $model = null)
{
    $form = new Form\NestedForm($column, $model);

    if ($this->form instanceof WidgetForm) {
        $form->setWidgetForm($this->form);
    } else {
        $form->setForm($this->form);
    }

    //Add
    if (!is_null($elementName)) {
        $form->setKey($elementName);
    }

    call_user_func($builder, $form);
```
```
protected function buildRelatedForms()
{
    omit......

    if ($values = old($this->column)) {
        foreach ($values as $key => $data) {
            if ($data[NestedForm::REMOVE_FLAG_NAME] == 1) {
                continue;
            }

            $model = $relation->getRelated()->replicate()->forceFill($data);

            //Add $key to argument $elementName.
            $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $key, $model)
                ->fill($data);
        }
    } else {
```

The `Encore\Admin\Form\Field\Table` class extends from the hasMany class, so I changed it too.

Thank you.