### PR TITLE
feat: Add number type to grid editables

### DIFF
--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -68,6 +68,13 @@ class Editable extends AbstractDisplayer
     }
 
     /**
+     * Number type editable
+     */
+    public function number()
+    {
+    }
+
+    /**
      * Select type editable.
      *
      * @param array|\Closure $options
@@ -217,7 +224,16 @@ STR;
             return "$name='$attribute'";
         })->implode(' ');
 
-        $html = $this->type === 'select' ? '' : $this->value;
+        switch ($this->type) {
+            case 'select':
+                $html = '';
+                break;
+            case 'number':
+                $html = number_format($this->value);
+                break;
+            default:
+                $html = $this->value;
+        }
 
         return "<a $attributes>{$html}</a>";
     }


### PR DESCRIPTION
Use it like this
```
$grid->column('price', __('Price'))->editable('number');
```

In this way you view number as comma separated but you can edit them without problem