### PR TITLE
bugfix preg_match function in PHP>=8.1 version, the subject parameter…

### DIFF
--- a/src/Auth/Database/Administrator.php
+++ b/src/Auth/Database/Administrator.php
@@ -47,6 +47,10 @@ class Administrator extends Model implements AuthenticatableContract
      */
     public function getAvatarAttribute($avatar)
     {
+        if($avatar === null) {
+            $avatar = null;
+        }
+
         if (url()->isValidUrl($avatar)) {
             return $avatar;
         }


### PR DESCRIPTION
因为创建用户的时候,头像可以缺省,这是默认的行为,但这个行为在PHP8.1以后会引起这样一个问题
`preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in`