### PR TITLE
修复列表不显示导出按钮和导出报错

### DIFF
--- a/src/Grid/Concerns/CanExportGrid.php
+++ b/src/Grid/Concerns/CanExportGrid.php
@@ -88,7 +88,7 @@ trait CanExportGrid
      */
     public function showExportBtn()
     {
-        return $this->option('show_exporter');
+        return $this->option('show_exporter', true);
     }
 
     /**
@@ -120,7 +120,8 @@ trait CanExportGrid
             return;
         }
 
-        $this->getExporter($scope)->setCallback($callback);
+        //$this->getExporter($scope)->setCallback($callback);
+        $this->getExporter($scope)->export();
 
         return $this;
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25996631/183009901-de22c485-616d-4d46-a1dc-dd2debb72abe.png)
以这种方式导出，列表右上角未显示导出按钮，且有导出按钮后导出也会报错