### PR TITLE
encode multibyte Unicode characters literally

### DIFF
--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -425,7 +425,7 @@ HTML;
             if (json_last_error() == 0) {
                 $field->border = false;
 
-                return '<pre><code>'.json_encode($content, JSON_PRETTY_PRINT).'</code></pre>';
+                return '<pre><code>'.json_encode($content, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE).'</code></pre>';
             }
 
             return $value;

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -425,7 +425,7 @@ HTML;
             if (json_last_error() == 0) {
                 $field->border = false;
 
-                return '<pre><code>'.json_encode($content, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE).'</code></pre>';
+                return '<pre><code>'.json_encode($content, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE).'</code></pre>';
             }
 
             return $value;


### PR DESCRIPTION
add JSON_UNESCAPED_UNICODE bitmask to json_encode() method to encode multibyte Unicode characters (for example, Chinese characters) literally (default is to escape as \uXXXX).