### PR TITLE
修正preg_match()函数第二个参数需要为字符串

### DIFF
--- a/src/Auth/Database/Administrator.php
+++ b/src/Auth/Database/Administrator.php
@@ -47,7 +47,7 @@ class Administrator extends Model implements AuthenticatableContract
      */
     public function getAvatarAttribute($avatar)
     {
-        if (url()->isValidUrl($avatar)) {
+        if ($avatar && url()->isValidUrl($avatar)) {
             return $avatar;
         }
 


### PR DESCRIPTION
高版本的php中对preg_match()的严谨入参，如果第二个参数传`null`，则会发生以下错误。
```
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /vendor/laravel/framework/src/Illuminate/Routing/UrlGenerator.php on line 625
```