### PR TITLE
fix: empty http path and method in permission allows any route open;

### DIFF
--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -64,7 +64,7 @@ class Permission extends Model
     public function shouldPassThrough(Request $request): bool
     {
         if (empty($this->http_method) && empty($this->http_path)) {
-            return true;
+            return false;
         }
 
         $method = $this->http_method;

--- a/tests/PermissionsTest.php
+++ b/tests/PermissionsTest.php
@@ -199,9 +199,9 @@ class PermissionsTest extends TestCase
     {
         //  1.add a permission without http_path and http_method
         $permission = Permission::create([
-            'slug' => 'not-http-based-permission',
-            'name' => 'Not http based permission',
-            'http_path' => '',
+            'slug'        => 'not-http-based-permission',
+            'name'        => 'Not http based permission',
+            'http_path'   => '',
             'http_method' => [''],
         ]);
 

--- a/tests/PermissionsTest.php
+++ b/tests/PermissionsTest.php
@@ -3,6 +3,7 @@
 use Encore\Admin\Auth\Database\Administrator;
 use Encore\Admin\Auth\Database\Permission;
 use Encore\Admin\Auth\Database\Role;
+use Illuminate\Http\Request;
 
 class PermissionsTest extends TestCase
 {
@@ -192,6 +193,21 @@ class PermissionsTest extends TestCase
             ->seeInDatabase(config('admin.database.role_permissions_table'), ['role_id' => 2, 'permission_id' => 6]);
 
         $this->assertTrue(Administrator::find(2)->can('can-remove'));
+    }
+
+    public function testPermissionWithoutHttpMethodAndHttpPath()
+    {
+        //  1.add a permission without http_path and http_method
+        $permission = Permission::create([
+            'slug' => 'not-http-based-permission',
+            'name' => 'Not http based permission',
+            'http_path' => '',
+            'http_method' => [''],
+        ]);
+
+        // 2.check that this permissions does not pass through protected routes (as it is checked in the Permission middleware)
+        $request = Request::create('admin/auth/permissions');
+        $this->assertFalse($permission->shouldPassThrough($request));
     }
 
     public function testEditPermission()


### PR DESCRIPTION
Original issue -- #5739 
I can't tell why this was designed like that, and the chances that after 6+ years it's safe to change it are not very high. Still, there's really no indication anywhere on the "Permission create" page that any Permission without `http_path` and `http_method` filled will give full access to any route and method. 
It may be better to restrict empty values there (eg make `http_path` required) to prevent this.