### PR TITLE
fix: $_user_ not defined

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -56,7 +56,7 @@
 <script>
     function LA() {}
     LA.token = "{{ csrf_token() }}";
-    LA.user = @json($_user_);
+    LA.user = @json($_user_ ?? '_user_');
 </script>
 
 <!-- REQUIRED JS SCRIPTS -->


### PR DESCRIPTION
This error was submitted for fix in 19, but it was not successfully merged to the master division, and currently new installations still report this error and cannot access the backend.