### PR TITLE
Adding new Search translation string to the main sidebar.

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -33,6 +33,7 @@ return [
     'collapse'              => 'Collapse',
     'filter'                => 'Filter',
     'search'                => 'Search',
+    'sidebar_search'        => 'Search...',
     'close'                 => 'Close',
     'show'                  => 'Show',
     'entries'               => 'entries',

--- a/resources/lang/es/admin.php
+++ b/resources/lang/es/admin.php
@@ -33,6 +33,7 @@ return [
     'collapse'              => 'Colapsar',
     'filter'                => 'Filtrar',
     'search'                => 'Buscar',
+    'sidebar_search'        => 'Buscar...',
     'close'                 => 'Cerrar',
     'show'                  => 'Mostrar',
     'entries'               => 'Entradas',

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -19,7 +19,7 @@
         <!-- search form (Optional) -->
         <form class="sidebar-form" style="overflow: initial;" onsubmit="return false;">
             <div class="input-group">
-                <input type="text" autocomplete="off" class="form-control autocomplete" placeholder="{{ __('admin.sidebar_search') }}">
+                <input type="text" autocomplete="off" class="form-control autocomplete" placeholder="{{ trans('admin.sidebar_search') }}">
               <span class="input-group-btn">
                 <button type="submit" name="search" id="search-btn" class="btn btn-flat"><i class="fa fa-search"></i>
                 </button>

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -19,7 +19,7 @@
         <!-- search form (Optional) -->
         <form class="sidebar-form" style="overflow: initial;" onsubmit="return false;">
             <div class="input-group">
-                <input type="text" autocomplete="off" class="form-control autocomplete" placeholder="Search...">
+                <input type="text" autocomplete="off" class="form-control autocomplete" placeholder="{{ __('admin.sidebar_search') }}">
               <span class="input-group-btn">
                 <button type="submit" name="search" id="search-btn" class="btn btn-flat"><i class="fa fa-search"></i>
                 </button>


### PR DESCRIPTION
## Context
While Installing a new fresh instalation of laravel admin I noticed there was not translation string for the search sidebar.

## What is this
- I added a new translation string (`sidebar_search`) to `resources/lang/en/admin.php` and `resources/lang/es/admin.php`
- I updated the `resources/views/partials/sidebar.blade.php` view with the new translations.