### PR TITLE
[bugfix] event.value is not evaluated when the value is array

### DIFF
--- a/src/Form/Field/CanCascadeFields.php
+++ b/src/Form/Field/CanCascadeFields.php
@@ -214,7 +214,7 @@ trait CanCascadeFields
     cascade_groups.forEach(function (event) {
         var default_value = '{$this->getValueByJs()}' + '';
         var class_name = event.class;
-        f( operator_table[event.operator](default_value, event.value) ) {
+        if( operator_table[event.operator](default_value, event.value) ) {
             $('.'+class_name+'').removeClass('hide');
         }
     });

--- a/src/Form/Field/CanCascadeFields.php
+++ b/src/Form/Field/CanCascadeFields.php
@@ -214,7 +214,7 @@ trait CanCascadeFields
     cascade_groups.forEach(function (event) {
         var default_value = '{$this->getValueByJs()}' + '';
         var class_name = event.class;
-        if(default_value == event.value) {
+        f( operator_table[event.operator](default_value, event.value) ) {
             $('.'+class_name+'').removeClass('hide');
         }
     });


### PR DESCRIPTION
The conditional form generator is not work properly when IN operator is used. 

```
        $form->select('some_type'))
            ->rules('required')
            ->options([1, 2, 3, 4, 5])
            ->when('in', [
                1,
                2,
            ], function (Form $form) {
                $form->hasMany('xxxx', 'yyyyyy', function (Form\NestedForm $nested_form) use ($form) {
                    // do something
                })->useTable();
            });
```

In this case above, cascade_groups is generated like this.
```
var cascade_groups = [{"class":"cascade-type-312d32","operator":"in","value":["1","2"]}];
```
and hide class is not removed correctly because the value is not expect array. 
```
if(default_value == event.value) {
```



