### PR TITLE
Replace "<input>" to "<textarea>" in Copyable 

### DIFF
--- a/src/Grid/Displayers/Copyable.php
+++ b/src/Grid/Displayers/Copyable.php
@@ -17,7 +17,7 @@ class Copyable extends AbstractDisplayer
 $('#{$this->grid->tableID}').on('click','.grid-column-copyable',(function (e) {
     var content = $(this).data('content');
     
-    var temp = $('<input>');
+    var temp = $('<textarea>');
     
     $("body").append(temp);
     temp.val(content).select();


### PR DESCRIPTION
replace "<input>" to "<textarea>" in Copyable , fix the issue of can not copy Line breaks in "data-content"