### PR TITLE
fix: when event operator is not "equal", default value not matched

### DIFF
--- a/src/Form/Field/CanCascadeFields.php
+++ b/src/Form/Field/CanCascadeFields.php
@@ -214,7 +214,7 @@ trait CanCascadeFields
     cascade_groups.forEach(function (event) {
         var default_value = '{$this->getValueByJs()}' + '';
         var class_name = event.class;
-        if(default_value == event.value) {
+        if(operator_table[event.operator](default_value, event.value)) {
             $('.'+class_name+'').removeClass('hide');
         }
     });


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e18b4e7b-20a2-467d-952f-1720edca0257)

fix CanCascadeFields, "when" default value condition as same as in "select" value change event 